### PR TITLE
ap - only pass props to FormRow children in BoundForms

### DIFF
--- a/src/components/BoundForm.js
+++ b/src/components/BoundForm.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Form } from 'reactstrap';
+import FormRow from './FormRow';
 import noop from 'lodash/noop';
 import set from 'lodash/set';
 
@@ -39,6 +40,8 @@ class BoundForm extends React.Component {
 
   render() {
     const children = React.Children.map(this.props.children, child => {
+      if (child.type !== FormRow) { return child; } // TODO make this better, using Context?
+
       const value = this.state.formData[child.props.name] || '';
       const feedback = this.props.errors[child.props.name];
       const color = feedback ? 'danger' : null;

--- a/test/components/BoundForm.spec.js
+++ b/test/components/BoundForm.spec.js
@@ -19,6 +19,8 @@ describe('<BoundForm />', () => {
     }
   };
 
+  data[undefined] = 'not good' // For testing items that don't have a name
+
   const errors = {
     firstName: "Can't be Glenn"
   }
@@ -35,6 +37,7 @@ describe('<BoundForm />', () => {
 
   const component = shallow(
     <BoundForm object={data} errors={errors} onSubmit={submitFunc} onChange={changeFunc}>
+      <h1>Title</h1>
       <FormRow label="First Name" name="firstName" />
       <FormRow label="Last Name" name="lastName" />
       <FormRow type="checkbox" label="Foobar" name="checkboxes">
@@ -44,6 +47,11 @@ describe('<BoundForm />', () => {
       <FormRow type={Composite} name="thing" />
     </BoundForm>
   );
+
+  it('should not add props to non-FormRows', () => {
+    const title = component.find('h1');
+    assert.equal(title.prop('value'), undefined);
+  });
 
   it('should provide value from data object', () => {
     const row = component.find('[name="firstName"]');


### PR DESCRIPTION
Fixes a bug where non-FormRow children get the props they don't want/need and cause an error in the console.