### PR TITLE
zw - adding FileInput for use in a BoundForm

### DIFF
--- a/src/components/FileInput.js
+++ b/src/components/FileInput.js
@@ -1,0 +1,32 @@
+import React, { Component } from 'react';
+import { Input } from 'reactstrap';
+
+class FileInput extends Component {
+
+  onChange = changeEvent => {
+    if (this.props.onChange) {
+      this.props.onChange(changeEvent.target.files);
+    }
+  }
+
+  render() {
+    const {
+      // unused, but this takes it out of ...props
+      type,
+      onChange,
+      // these are used
+      name,
+      ...props
+    } = this.props;
+    return (
+      <Input type="file" name={name} onChange={this.onChange} {...props} />
+    );
+  }
+}
+
+FileInput.propTypes = {
+  onChange: React.PropTypes.function,
+  name: React.PropTypes.string.isRequired
+};
+
+export default FileInput;

--- a/src/components/FormRow.js
+++ b/src/components/FormRow.js
@@ -4,11 +4,13 @@ import { FormGroup, Input, Label, Col, FormFeedback, FormText } from 'reactstrap
 import CheckboxInput from './CheckboxInput';
 import RadioInput from './RadioInput';
 import StaticInput from './StaticInput';
+import FileInput from './FileInput';
 
 const typeTranslations = {
   checkbox: CheckboxInput,
   radio: RadioInput,
-  static: StaticInput
+  static: StaticInput,
+  file: FileInput
 };
 
 function determineElement(type) {

--- a/stories/Forms.js
+++ b/stories/Forms.js
@@ -105,6 +105,7 @@ storiesOf('Forms', module)
         <FormChoice value="shuttle">Imperial Shuttle</FormChoice>
       </BoundFormRow>
       <BoundFormRow type={AddressInput} name="address" label="Address" />
+      <BoundFormRow type="file" label="Death Star Schematics" name="deathStarPlans" multiple/>
       <button className="btn btn-primary">Submit</button>
     </BoundForm>
   ));

--- a/test/components/FileInput.spec.js
+++ b/test/components/FileInput.spec.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import sinon from 'sinon';
+import assert from 'assert';
+
+import FileInput from '../../src/components/FileInput';
+
+class MockFileReader {
+  readAsDataURL = stub();
+}
+
+describe('<FileInput />', () => {
+  const sandbox = sinon.sandbox.create();
+  const onChangeStub = sandbox.stub()
+  beforeEach(() => {
+    sandbox.restore();
+  });
+
+  const wrapper = shallow(<FileInput name="aFileInput" onChange={onChangeStub} />);
+  it('renders an <input> with type file', () => {
+    assert.equal(wrapper.find('Input').prop('type'), 'file');
+  });
+
+  it('rendered <input> has correct name', () => {
+    assert.equal(wrapper.find('Input').prop('name'), 'aFileInput');
+  });
+
+  it('calls supplied onChange function when file selected', () => {
+    wrapper.find('Input').simulate('change', {
+      target: { files: [{ name: 'your.mom' }] }
+    });
+
+    const expectedValue = [{name: 'your.mom'}];
+    assert(onChangeStub.calledWith(expectedValue));
+  });
+
+  it('calls supplied onChange function when multiple files selected', () => {
+    wrapper.find('Input').simulate('change', {
+      target: {
+        files: [
+          {name: 'your.mom'},
+          {name: 'karans.mom'},
+          {name: 'justins.mom'},
+        ]}
+    });
+
+    const expectedValue = [
+      {name: 'your.mom'},
+      {name: 'karans.mom'},
+      {name: 'justins.mom'}
+    ];
+    assert(onChangeStub.calledWith(expectedValue));
+  });
+});

--- a/test/components/FormRow.spec.js
+++ b/test/components/FormRow.spec.js
@@ -8,6 +8,7 @@ import FormRow from '../../src/components/FormRow';
 import StaticInput from '../../src/components/StaticInput';
 import RadioInput from '../../src/components/RadioInput';
 import CheckboxInput from '../../src/components/CheckboxInput';
+import FileInput from '../../src/components/FileInput';
 
 describe('<FormRow />', () => {
   describe('by default', () => {
@@ -144,6 +145,16 @@ describe('<FormRow />', () => {
 
     it('should render a RadioInput', () => {
       assert.equal(component.find(RadioInput).length, 1);
+    });
+  });
+
+  describe('with file type', () => {
+    const wrapper = shallow(
+      <FormRow type="file" />
+    );
+
+    it('should render a FileInput', () => {
+      assert.equal(wrapper.find(FileInput).length, 1);
     });
   });
 


### PR DESCRIPTION
The FileInput is used when the BoundFormRow type is 'file'.
The FileInput will updates the BoundForm state with a list of file objects,
one for each file selected.
