### PR TITLE
Dont use card in LabelBadge

### DIFF
--- a/src/components/LabelBadge.js
+++ b/src/components/LabelBadge.js
@@ -26,7 +26,9 @@ export default class LabelBadge extends React.Component {
     };
 
     return (
-      <span className={`card rounded d-inline-flex flex-row justify-content-between align-items-center ${className}`}>
+      //TODO: use '.card' instead of hard coded boarder style for label badge
+      // we aren't doing it right now because apm and bootstrap-apm has a conflict for .card
+      <span className={`rounded d-inline-flex flex-row justify-content-between align-items-center ${className} ${styles.outer}`}>
         {label ?
           <strong className={labelClasses} style={style}>
             <span className={styles.trim}>{label}</span>

--- a/src/components/LabelBadge.scss
+++ b/src/components/LabelBadge.scss
@@ -1,3 +1,10 @@
+//TODO: use color class or variable
+$border-color: #e0e0e0;
+
+.outer {
+  border: 1px solid $border-color;
+}
+
 .trim {
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
apm and bootstrap-apm has a conflict for .card, so LabelBadge is used in apm, it will inherit both styles