### PR TITLE
Add support for negative numbers to currency input

### DIFF
--- a/src/components/CurrencyInput.js
+++ b/src/components/CurrencyInput.js
@@ -4,22 +4,39 @@ import createNumberMask from 'text-mask-addons/dist/createNumberMask';
 import { InputGroup, InputGroupAddon } from 'reactstrap';
 
 // TODO support I18n
-const CurrencyInput = ({ size, ...props }) => (
-  <InputGroup size={size} className={props.className}>
-    <InputGroupAddon>$</InputGroupAddon>
-    <MaskedInput
-      {...props}
-      className="form-control"
-      mask={createNumberMask({
-        allowDecimal: true,
-        prefix: ''
-      })}
-    />
-  </InputGroup>
-);
+const CurrencyInput = ({ size, ...props }) => {
+  const inputProps = Object.assign({}, props, {
+    className: 'form-control',
+    mask: createNumberMask({
+      allowDecimal: props.allowDecimal,
+      allowNegative: props.allowNegative,
+      includeThousandsSeparator: props.includeThousandsSeparator,
+      prefix: ''
+    }),
+  });
+  delete inputProps.allowDecimal;
+  delete inputProps.allowNegative;
+  delete inputProps.includeThousandsSeparator;
+
+  return (
+    <InputGroup size={size} className={props.className}>
+      <InputGroupAddon>$</InputGroupAddon>
+      <MaskedInput {...inputProps} />
+    </InputGroup>
+  );
+};
+
+CurrencyInput.defaultProps = {
+  allowDecimal: true,
+  allowNegative: false,
+  includeThousandsSeparator: true,
+};
 
 CurrencyInput.propTypes = {
+  allowDecimal: React.PropTypes.bool,
+  allowNegative: React.PropTypes.bool,
   className: PropTypes.number,
+  includeThousandsSeparator: React.PropTypes.bool,
   size: PropTypes.string
 };
 

--- a/stories/CurrencyInput.js
+++ b/stories/CurrencyInput.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { storiesOf } from '@kadira/storybook';
+
+import { CurrencyInput } from '../src';
+
+storiesOf('CurrencyInput', module)
+  .addWithInfo('default props', () => (
+    <CurrencyInput />
+  ))
+  .addWithInfo('allow negative', () => (
+    <CurrencyInput allowNegative />
+  ))
+  .addWithInfo('disallow decimal', () => (
+    <CurrencyInput allowDecimal={false} />
+  ))
+  .addWithInfo('disallow comma', () => (
+    <CurrencyInput includeThousandsSeparator={false} />
+  ));

--- a/stories/index.js
+++ b/stories/index.js
@@ -15,6 +15,7 @@ import './Tooltip';
 // Form fields
 import './Forms';
 import './Address';
+import './CurrencyInput';
 import './DateMonth';
 import './InputGroup';
 import './Select';

--- a/test/components/CurrencyInput.spec.js
+++ b/test/components/CurrencyInput.spec.js
@@ -23,37 +23,73 @@ describe('<CurrencyInput />', () => {
     assert.equal(input.get(0).value, '1,234.56');
   });
 
-  it('should accept comma formatted values', () => {
-    const component = mount(<CurrencyInput onChange={callback} value="123,456,789.99999" />);
-    const input = component.find('input');
-    assert.equal(input.get(0).value, '123,456,789.99');
+  context('thousands separators', () => {
+    it('should default to true', () => {
+      const component = mount(<CurrencyInput onChange={callback} value="123,456,789.99999" />);
+      const input = component.find('input');
+      assert.equal(input.get(0).value, '123,456,789.99');
+    });
+
+    it('can be disabled', () => {
+      const component = mount(<CurrencyInput value="123,456" includeThousandsSeparator={false} />);
+      const input = component.find('input');
+      assert.equal(input.get(0).value, '123456');
+    });
+  });
+
+  context('negative numbers', () => {
+    it('should be disabled by default', () => {
+      const component = mount(<CurrencyInput value="-123" />);
+      const input = component.find('input');
+      assert.equal(input.get(0).value, '123');
+    });
+
+    it('can be enabled', () => {
+      const component = mount(<CurrencyInput value="-123" allowNegative />);
+      const input = component.find('input');
+      assert.equal(input.get(0).value, '-123');
+    });
+  });
+
+  context('decimals', () => {
+    it('should be enabled by default', () => {
+      const component = mount(<CurrencyInput value="123.45" />);
+      const input = component.find('input');
+      assert.equal(input.get(0).value, '123.45');
+    });
+
+    it('can be disabled', () => {
+      const component = mount(<CurrencyInput value="123.45" allowDecimal={false} />);
+      const input = component.find('input');
+      assert.equal(input.get(0).value, '12,345');
+    });
+
+    it('should truncate more than 2 decimals', () => {
+      const component = mount(<CurrencyInput value={1234.56789} />);
+      const input = component.find('input');
+
+      assert.equal(input.get(0).value, '1,234.56');
+    });
+
+    // TODO skipped pending this issue/question: https://github.com/text-mask/text-mask/issues/372
+    it.skip('should zero pad 1 decimal', () => {
+      const component = mount(<CurrencyInput onChange={callback} value={1234.5} />);
+      const input = component.find('input');
+
+      assert.equal(input.get(0).value, '1,234.50');
+    });
+
+    it.skip('should zero pad no decimals', () => {
+      const component = mount(<CurrencyInput onChange={callback} value={1234} />);
+      const input = component.find('input');
+
+      assert.equal(input.get(0).value, '1,234.00');
+    });
   });
 
   it('should not format invalid values', () => {
     const component = mount(<CurrencyInput onChange={callback} value="Veni, Vedi, Vici" />);
     const input = component.find('input');
     assert.equal(input.get(0).value, '');
-  });
-
-  it('should truncate more than 2 decimals', () => {
-    const component = mount(<CurrencyInput onChange={callback} value={1234.56789} />);
-    const input = component.find('input');
-
-    assert.equal(input.get(0).value, '1,234.56');
-  });
-
-  // TODO skipped pending this issue/question: https://github.com/text-mask/text-mask/issues/372
-  it.skip('should zero pad 1 decimal', () => {
-    const component = mount(<CurrencyInput onChange={callback} value={1234.5} />);
-    const input = component.find('input');
-
-    assert.equal(input.get(0).value, '1,234.50');
-  });
-
-  it.skip('should zero pad no decimals', () => {
-    const component = mount(<CurrencyInput onChange={callback} value={1234} />);
-    const input = component.find('input');
-
-    assert.equal(input.get(0).value, '1,234.00');
   });
 });


### PR DESCRIPTION
This PR exposes a few configuration settings in the currency input to allow better control over which types of numbers are allowed.

Specifically this PR adds:
- support for negative numbers
- support for disabling decimals
- support for removing automatic thousand separators

The thousand separators change is added due to the current user experience issues with real time inline formatting of numbers.  The behavior is also inconsistent with the rest of APM, which formats after the input loses focus.

All of these changes have preserved the current defaults, so no change should be evident for existing users.