### PR TITLE
Fix currency input bugs

### DIFF
--- a/src/components/CurrencyInput.js
+++ b/src/components/CurrencyInput.js
@@ -3,16 +3,34 @@ import MaskedInput from 'react-text-mask';
 import createNumberMask from 'text-mask-addons/dist/createNumberMask';
 import { InputGroup, InputGroupAddon } from 'reactstrap';
 
+/**
+ * In the case where the user enters an extra "." at the end of the input the default behavior will
+ * be to remove the original decimal point and keep the new one, resulting in the value being
+ * multiplied by 100.  If we detect an additional decimal point we can ignore the extra character.
+ */
+function preventMultipleDecimalPoint(conformedValue, config) {
+  let result = conformedValue;
+  if (config.rawValue.match(/\..*\./)) {
+    result = config.previousConformedValue;
+  }
+  return result;
+}
+
 // TODO support I18n
 const CurrencyInput = ({ size, ...props }) => {
   const inputProps = Object.assign({}, props, {
     className: 'form-control',
+    // There is a weird bug in the MaskedInput where if the "value" prop gets set to null the
+    // input value gets set to "_".  Setting guide to false instead of undefined solves the
+    // problem.
+    guide: false,
     mask: createNumberMask({
       allowDecimal: props.allowDecimal,
       allowNegative: props.allowNegative,
       includeThousandsSeparator: props.includeThousandsSeparator,
       prefix: ''
     }),
+    pipe: preventMultipleDecimalPoint,
   });
   delete inputProps.allowDecimal;
   delete inputProps.allowNegative;

--- a/test/components/CurrencyInput.spec.js
+++ b/test/components/CurrencyInput.spec.js
@@ -71,6 +71,14 @@ describe('<CurrencyInput />', () => {
       assert.equal(input.get(0).value, '1,234.56');
     });
 
+    it('should ignore additional decimal points', () => {
+      const component = mount(<CurrencyInput value={1234.56} />);
+      const input = component.find('input');
+      input.get(0).value = '1,234.56.';
+      input.simulate('input');
+      assert.equal(input.get(0).value, '1,234.56');
+    });
+
     // TODO skipped pending this issue/question: https://github.com/text-mask/text-mask/issues/372
     it.skip('should zero pad 1 decimal', () => {
       const component = mount(<CurrencyInput onChange={callback} value={1234.5} />);


### PR DESCRIPTION
This PR fixes two bugs in the currency input:
1. when the `value` prop of the currency input changes to `null`, the input value changes to `_`. This is actually a bug in the underlying `MaskedInput` but has been worked around by ensuring `guide` is set to `false`.
2. if a second decimal point is added to a value the original decimal point is replaced, resulting in the value being multiplied by 100. The behavior has now been changed to instead disallow the addition of a second period.