### PR TITLE
ps - fix margin on some alert examples

### DIFF
--- a/stories/Alerts.js
+++ b/stories/Alerts.js
@@ -12,18 +12,18 @@ storiesOf('Alerts', module)
       icon={boolean('icon', false)}
       dismissible={boolean('dismissible', false)}
     >
-      <p>{text('content', `Lorem ipsum dolor sit amet, consectetur adipiscing
+      {text('content', `Lorem ipsum dolor sit amet, consectetur adipiscing
 elit, sed do eiusmod tempor incididunt ut labore
 et dolore magna aliqua.  Ut enim ad minim veniam,
 quis nostrud exercitation ullamco laboris nisi ut
-aliquip ex ea commodo consequat.`)}</p>
+aliquip ex ea commodo consequat.`)}
     </Alert>
   ))
   .addWithInfo('Colors', () => (
     <div>
       <Alert>
         <p>The default alert is a "warning". It supports any sort of custom markup.</p>
-        <p className="mb-0"><Button>Like This!</Button></p>
+        <div><Button>Like This!</Button></div>
       </Alert>
       <Alert color="success">
         You can specify an alert color. This one has <code>color="success"</code>
@@ -41,15 +41,13 @@ aliquip ex ea commodo consequat.`)}</p>
         You can specify an alert color. This one has <code>color="success"</code>
       </Alert>
       <Alert icon color="danger">
-        <p className="mb-0">
-          Humblebrag prism twee, gochujang seitan whatever asymmetrical ramps enamel pin austin
-          salvia swag helvetica. Chartreuse food truck tofu raclette, 3 wolf moon poke chia paleo
-          skateboard. Pickled tote bag echo park raclette. Irony fashion axe sartorial, cornhole
-          jean shorts vaporware flannel salvia glossier beard 3 wolf moon. Literally semiotics
-          hammock irony cred, bicycle rights lomo selvage tousled vegan 8-bit. Four loko cardigan
-          live-edge truffaut pour-over, helvetica chia brooklyn swag pug scenester kogi pitchfork
-          leggings yuccie. Ethical put a bird on it portland vape YOLO.
-        </p>
+        Humblebrag prism twee, gochujang seitan whatever asymmetrical ramps enamel pin austin
+        salvia swag helvetica. Chartreuse food truck tofu raclette, 3 wolf moon poke chia paleo
+        skateboard. Pickled tote bag echo park raclette. Irony fashion axe sartorial, cornhole
+        jean shorts vaporware flannel salvia glossier beard 3 wolf moon. Literally semiotics
+        hammock irony cred, bicycle rights lomo selvage tousled vegan 8-bit. Four loko cardigan
+        live-edge truffaut pour-over, helvetica chia brooklyn swag pug scenester kogi pitchfork
+        leggings yuccie. Ethical put a bird on it portland vape YOLO.
       </Alert>
       <Alert icon color="info">
         <strong>Heads up!</strong> This alert needs your attention, but it's not super important.


### PR DESCRIPTION
Some alert examples had some extra margin. This cleans it up.

Having a `<p>` with class `mb-0` is equivalent to a `<div>` due to the included `reboot.css`:

![image](https://cloud.githubusercontent.com/assets/1444314/23764340/09b03a4e-04b2-11e7-8dc2-08f3148cab3b.png)
