### PR TITLE
ps - remove lodash.includes and fix datemonth click outside

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "jsdom-global": "~2.1.0",
     "lodash.clonedeep": "~4.5.0",
     "lodash.flow": "^3.5.0",
-    "lodash.includes": "^4.2.0",
     "lodash.noop": "^3.0.1",
     "lodash.omit": "^4.5.0",
     "lodash.over": "^4.7.0",

--- a/src/components/datemonth/DateMonth.js
+++ b/src/components/datemonth/DateMonth.js
@@ -4,7 +4,6 @@ import { Icon } from '../../';
 import Label from './DateMonthLabel.js';
 import React, { Component } from 'react';
 import fecha from 'fecha';
-import includes from 'lodash.includes';
 import path from './path.js';
 import range from 'lodash.range';
 import styles from './DateMonth.scss';
@@ -42,7 +41,7 @@ export default class DateMonth extends Component {
   componentDidMount() {
     this.listener = event => {
       const container = this.base;
-      if (container && !includes(path(event), container)) {
+      if (container && path(event).indexOf(container) === -1) {
         this.setState({ open: false });
       }
       return true;
@@ -122,7 +121,7 @@ export default class DateMonth extends Component {
     const value = state.month && state.year ? `${state.month} ${state.year}` : props.value;
 
     return (
-      <div className={styles.dateMonth}>
+      <div className={styles.dateMonth} ref={el => { this.base = el; }}>
         <header>
           <InputGroup>
             <Input


### PR DESCRIPTION
DateMonth modal would not close correctly when outside of the modal was clicked. Fixing it also causes us to no longer need `lodash.includes`.

Fixes #80