### PR TITLE
Clean up dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,9 +25,7 @@
     "prepublish": "npm run dist",
     "postpublish": "git push --no-verify && git push --tags"
   },
-  "dependencies": {
-    "babel-polyfill": "~6.13.0",
-    "classnames": "^2.2.5",
+  "peerDependencies": {
     "react": "~15.4.0",
     "react-addons-css-transition-group": "^15.4.0",
     "react-addons-transition-group": "^15.4.0",
@@ -46,8 +44,10 @@
     "babel-loader": "~6.2.4",
     "babel-plugin-transform-class-properties": "^6.23.0",
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
+    "babel-polyfill": "~6.13.0",
     "babel-preset-es2015": "~6.14.0",
     "babel-preset-react": "~6.11.1",
+    "classnames": "^2.2.5",
     "css-loader": "~0.25.0",
     "enzyme": "^2.6.0",
     "eslint-config-appfolio-react": "~0.3.2",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,7 +19,7 @@ module.exports = {
   output: {
     path: path.resolve(__dirname, './dist'),
     filename: 'bundle.js',
-    library: 'xanthous',
+    library: 'ReactGears',
     libraryTarget: 'umd',
     umdNamedDefine: true
   },


### PR DESCRIPTION
- Move all external dependencies to peerDependencies group
- Update umd library name to ReactGears instead of Xanthouse.

For the future: right now we only consume this lib as a CommonJS dependency. We should consider changing our Library Target in `webpack.config.js` to `commonjs2`.

Fixes #76
Fixes #81

Merge this only after validating that all consumers of this library have the correct peerDependencies setup.