### PR TITLE
Update progress bar example to use default color by default

### DIFF
--- a/stories/Progress.js
+++ b/stories/Progress.js
@@ -7,7 +7,7 @@ import { Progress } from '../src';
 storiesOf('Progress', module)
   .addWithInfo('Live example', () => (
     <Progress
-      color={select('color', ['info', 'success', 'warning', 'danger'], 'info')}
+      color={select('color', ['', 'info', 'success', 'warning', 'danger'], '')}
       value={number('value', 50, {
         range: true,
         min: 0,


### PR DESCRIPTION
Allow the progress bar to show it's default color by updating the knob to allow picking default color.