### PR TITLE
Fix react-select focus issue

### DIFF
--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -6,6 +6,49 @@ import over from 'lodash.over';
 // Disables CSS modules to import as global:
 import './Select.scss';
 
+/**
+ * This is a workaround for a current bug in react-select where the currently focused item is not
+ * highlighted after updating the options list.
+ *
+ * This can be removed when a new version of react-select is released with this PR merged:
+ *   https://github.com/JedWatson/react-select/pull/1512
+ *   https://github.com/JedWatson/react-select/issues/1513
+ *   https://github.com/JedWatson/react-select/issues/1565
+ */
+function monkeyPatchReactSelectGetFocusableOptionIndex(element) {
+  if (!element) {
+    return;
+  }
+
+  // eslint-disable-next-line no-param-reassign
+  element.getFocusableOptionIndex = function getFocusableOptionIndex(selectedOption) {
+    // eslint-disable-next-line no-underscore-dangle
+    const options = this._visibleOptions;
+    if (!options.length) return null;
+
+    // eslint-disable-next-line prefer-const
+    let focusedOption = this.state.focusedOption || selectedOption;
+    if (focusedOption && !focusedOption.disabled) {
+      let focusedOptionIndex = -1;
+      options.some((option, index) => {
+        const isOptionEqual = option.value === focusedOption.value;
+        if (isOptionEqual) {
+          focusedOptionIndex = index;
+        }
+        return isOptionEqual;
+      });
+      if (focusedOptionIndex !== -1) {
+        return focusedOptionIndex;
+      }
+    }
+
+    for (let i = 0; i < options.length; i++) {
+      if (!options[i].disabled) return i;
+    }
+    return null;
+  };
+}
+
 class Select extends Component {
   static propTypes = {
     defaultValue: React.PropTypes.any,
@@ -38,6 +81,7 @@ class Select extends Component {
         onChange={over([this.updateValue, onChange])}
         value={value || this.state.value}
         {...props}
+        ref={element => { monkeyPatchReactSelectGetFocusableOptionIndex(element); }}
       />
     );
   }


### PR DESCRIPTION
There is a bug in react-select where the currently selected item will lose focus if the `options` list changes, even if the selected option still exists.

There is a PR to fix this on `react-select` https://github.com/JedWatson/react-select/pull/1512 but the author does not seem to be very resposive to PRs.

In the meantime this PR takes the fix and applies it directly within react-gears.  This is intended as a temporary fix until the real one gets merged.

Before:
![screen shot 2017-03-16 at 3 11 52 pm](https://cloud.githubusercontent.com/assets/37422/24020776/f02602e4-0a5a-11e7-9390-efa07a1aeed1.png)

After:
![screen shot 2017-03-16 at 3 10 15 pm](https://cloud.githubusercontent.com/assets/37422/24020781/f41ae40a-0a5a-11e7-9e31-32415587b313.png)
