### PR TITLE
rm: restyle react-select internals for better cursor position

### DIFF
--- a/src/components/Select.scss
+++ b/src/components/Select.scss
@@ -12,7 +12,7 @@
   @import '~react-select/scss/default.scss';
 
   // The default right padding for the input is 10px, which puts the cursor quite deep into the
-  // component.  By reducing this to 5px the input looks more natural and the cursor does not
+  // component.  By reducing this to 0.5rem the input looks more natural and the cursor does not
   // overlap any placeholder text.
   .Select-input {
     padding-left: 0.5rem;


### PR DESCRIPTION
Old: 
![image](https://cloud.githubusercontent.com/assets/7446202/25058489/c229e622-212e-11e7-8b68-d2e2581ac149.png)

New: 
![image](https://cloud.githubusercontent.com/assets/7446202/25058498/d3070e34-212e-11e7-85df-c1e6918a077c.png)

There shouldn't be any noticeable changes in other cases.
