### PR TITLE
Remove lodash.over

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "lodash.flow": "^3.5.0",
     "lodash.noop": "^3.0.1",
     "lodash.omit": "^4.5.0",
-    "lodash.over": "^4.7.0",
     "lodash.set": "^4.3.2",
     "mocha": "~3.0.2",
     "node-sass": "~3.10.0",

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import ReactSelect from 'react-select';
 import noop from 'lodash.noop';
-import over from 'lodash.over';
 
 // Disables CSS modules to import as global:
 import './Select.scss';
@@ -75,16 +74,20 @@ class Select extends Component {
     }
   }
 
-  updateValue = value => { this.setState({ value }); }
+  onChange = value => {
+    this.setState({ value });
+    this.props.onChange(value);
+  }
 
   render() {
-    const { value, onChange, ...props } = this.props;
+    const { value, ...props } = this.props;
+    delete props.onChange; // don't pass onChange prop to react-select
     const SelectElement = this.props.loadOptions ? ReactSelect.Async : ReactSelect;
 
     return (
       <SelectElement
         inputProps={{ ...props.inputProps, name: props.name || '' }}
-        onChange={over([this.updateValue, onChange])}
+        onChange={this.onChange}
         value={value || this.state.value}
         {...props}
         ref={element => { monkeyPatchReactSelectGetFocusableOptionIndex(element); }}


### PR DESCRIPTION
This PR removes the lodash.over dependency to reduce the bundle size.

Before:
```
bundle.js  215 kB
```

After:
```
bundle.js  202 kB
```