### PR TITLE
Upgrade react-select and remove monkey patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "postcss-loader": "~0.13.0",
     "react-addons-test-utils": "^15.4.0",
     "react-fontawesome": "^1.4.0",
-    "react-select": "^1.0.0-rc.2",
+    "react-select": "^1.0.0-rc.4",
     "react-text-mask": "^0.19.0",
     "sass-loader": "~4.0.0",
     "sinon": "^1.17.6",

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -5,49 +5,6 @@ import noop from 'lodash.noop';
 // Disables CSS modules to import as global:
 import './Select.scss';
 
-/**
- * This is a workaround for a current bug in react-select where the currently focused item is not
- * highlighted after updating the options list.
- *
- * This can be removed when a new version of react-select is released with this PR merged:
- *   https://github.com/JedWatson/react-select/pull/1512
- *   https://github.com/JedWatson/react-select/issues/1513
- *   https://github.com/JedWatson/react-select/issues/1565
- */
-function monkeyPatchReactSelectGetFocusableOptionIndex(element) {
-  if (!element) {
-    return;
-  }
-
-  // eslint-disable-next-line no-param-reassign
-  element.getFocusableOptionIndex = function getFocusableOptionIndex(selectedOption) {
-    // eslint-disable-next-line no-underscore-dangle
-    const options = this._visibleOptions;
-    if (!options.length) return null;
-
-    // eslint-disable-next-line prefer-const
-    let focusedOption = this.state.focusedOption || selectedOption;
-    if (focusedOption && !focusedOption.disabled) {
-      let focusedOptionIndex = -1;
-      options.some((option, index) => {
-        const isOptionEqual = option.value === focusedOption.value;
-        if (isOptionEqual) {
-          focusedOptionIndex = index;
-        }
-        return isOptionEqual;
-      });
-      if (focusedOptionIndex !== -1) {
-        return focusedOptionIndex;
-      }
-    }
-
-    for (let i = 0; i < options.length; i++) {
-      if (!options[i].disabled) return i;
-    }
-    return null;
-  };
-}
-
 class Select extends Component {
   static propTypes = {
     defaultValue: React.PropTypes.any,
@@ -90,7 +47,6 @@ class Select extends Component {
         onChange={this.onChange}
         value={value || this.state.value}
         {...props}
-        ref={element => { monkeyPatchReactSelectGetFocusableOptionIndex(element); }}
       />
     );
   }


### PR DESCRIPTION
A new version of react-select has been released that includes the fix that we monkey patched here https://github.com/appfolio/react-gears/pull/175.

This PR updates the react-select version and removes the monkey patch.