### PR TITLE
Fix currency decimal bug

### DIFF
--- a/src/components/CurrencyInput.js
+++ b/src/components/CurrencyInput.js
@@ -1,6 +1,16 @@
 import React, { PropTypes } from 'react';
 import MaskedInput from 'react-text-mask';
-import createNumberMask from 'text-mask-addons/dist/createNumberMask';
+
+//
+// TODO there is currently a bug in MaskedInput that prevents users from entering decimal only currency values.
+// As of 06/05/2017 the issue has been fixed and has an open PR to react-text mask at
+// https://github.com/text-mask/text-mask/pull/542
+// The monkey patch imported below can be removed when the PR is merged and a new version of react-text-mask is
+// released.
+//
+//import createNumberMask from 'text-mask-addons/dist/createNumberMask';
+import createNumberMask from './CurrencyInput/createNumberMaskMonkeyPatch';
+
 import { InputGroup, InputGroupAddon } from 'reactstrap';
 
 /**

--- a/src/components/CurrencyInput/createNumberMaskMonkeyPatch.js
+++ b/src/components/CurrencyInput/createNumberMaskMonkeyPatch.js
@@ -1,0 +1,151 @@
+/* eslint-disable */
+
+//
+// The contents of this file are taken from
+//  https://raw.githubusercontent.com/realdah/text-mask/1929f7b8d2e3bffe23c3dcc0798833372802728c/addons/src/createNumberMask.js
+// and applies the changes from
+//   https://github.com/text-mask/text-mask/pull/542
+// This can be removed when the above PR is merged
+//
+
+const dollarSign = '$'
+const emptyString = ''
+const comma = ','
+const period = '.'
+const minus = '-'
+const minusRegExp = /-/
+const nonDigitsRegExp = /\D+/g
+const number = 'number'
+const digitRegExp = /\d/
+const caretTrap = '[]'
+
+export default function createNumberMask({
+  prefix = dollarSign,
+  suffix = emptyString,
+  includeThousandsSeparator = true,
+  thousandsSeparatorSymbol = comma,
+  allowDecimal = false,
+  decimalSymbol = period,
+  decimalLimit = 2,
+  requireDecimal = false,
+  allowNegative = false,
+  allowLeadingZeroes = false,
+  integerLimit = null
+} = {}) {
+  const prefixLength = prefix && prefix.length || 0
+  const suffixLength = suffix && suffix.length || 0
+  const thousandsSeparatorSymbolLength = thousandsSeparatorSymbol && thousandsSeparatorSymbol.length || 0
+
+  function numberMask(rawValue = emptyString) {
+    const rawValueLength = rawValue.length
+
+    if (
+      rawValue === emptyString ||
+      (rawValue[0] === prefix[0] && rawValueLength === 1)
+    ) {
+      return prefix.split(emptyString).concat([digitRegExp]).concat(suffix.split(emptyString))
+    } else if(
+      rawValue === decimalSymbol &&
+      allowDecimal
+    ) {
+      return prefix.split(emptyString).concat(['0', decimalSymbol, digitRegExp]).concat(suffix.split(emptyString))
+    }
+
+    const indexOfLastDecimal = rawValue.lastIndexOf(decimalSymbol)
+    const hasDecimal = indexOfLastDecimal !== -1
+    const isNegative = (rawValue[0] === minus) && allowNegative
+
+    let integer
+    let fraction
+    let mask
+
+    // remove the suffix
+    if (rawValue.slice(suffixLength * -1) === suffix) {
+      rawValue = rawValue.slice(0, suffixLength * -1)
+    }
+
+    if (hasDecimal && (allowDecimal || requireDecimal)) {
+      integer = rawValue.slice(rawValue.slice(0, prefixLength) === prefix ? prefixLength : 0, indexOfLastDecimal)
+
+      fraction = rawValue.slice(indexOfLastDecimal + 1, rawValueLength)
+      fraction = convertToMask(fraction.replace(nonDigitsRegExp, emptyString))
+    } else {
+      if (rawValue.slice(0, prefixLength) === prefix) {
+        integer = rawValue.slice(prefixLength)
+      } else {
+        integer = rawValue
+      }
+    }
+
+    if (integerLimit && typeof integerLimit === number) {
+      const thousandsSeparatorRegex = thousandsSeparatorSymbol === '.' ? '[.]' : `${thousandsSeparatorSymbol}`
+      const numberOfThousandSeparators = (integer.match(new RegExp(thousandsSeparatorRegex, 'g')) || []).length
+
+      integer = integer.slice(0, integerLimit + (numberOfThousandSeparators * thousandsSeparatorSymbolLength))
+    }
+
+    integer = integer.replace(nonDigitsRegExp, emptyString)
+
+    if (!allowLeadingZeroes) {
+      integer = integer.replace(/^0+(0$|[^0])/, '$1')
+    }
+
+    integer = (includeThousandsSeparator) ? addThousandsSeparator(integer, thousandsSeparatorSymbol) : integer
+
+    mask = convertToMask(integer)
+
+    if ((hasDecimal && allowDecimal) || requireDecimal === true) {
+      if (rawValue[indexOfLastDecimal - 1] !== decimalSymbol) {
+        mask.push(caretTrap)
+      }
+
+      mask.push(decimalSymbol, caretTrap)
+
+      if (fraction) {
+        if (typeof decimalLimit === number) {
+          fraction = fraction.slice(0, decimalLimit)
+        }
+
+        mask = mask.concat(fraction)
+      }
+
+      if (requireDecimal === true && rawValue[indexOfLastDecimal - 1] === decimalSymbol) {
+        mask.push(digitRegExp)
+      }
+    }
+
+    if (prefixLength > 0) {
+      mask = prefix.split(emptyString).concat(mask)
+    }
+
+    if (isNegative) {
+      // If user is entering a negative number, add a mask placeholder spot to attract the caret to it.
+      if (mask.length === prefixLength) {
+        mask.push(digitRegExp)
+      }
+
+      mask = [minusRegExp].concat(mask)
+    }
+
+    if (suffix.length > 0) {
+      mask = mask.concat(suffix.split(emptyString))
+    }
+
+    return mask
+  }
+
+  numberMask.instanceOf = 'createNumberMask'
+
+  return numberMask
+}
+
+function convertToMask(strNumber) {
+  return strNumber
+    .split(emptyString)
+    .map((char) => digitRegExp.test(char) ? digitRegExp : char)
+}
+
+// http://stackoverflow.com/a/10899795/604296
+function addThousandsSeparator(n, thousandsSeparatorSymbol) {
+  return n.replace(/\B(?=(\d{3})+(?!\d))/g, thousandsSeparatorSymbol)
+}

--- a/test/components/CurrencyInput.spec.js
+++ b/test/components/CurrencyInput.spec.js
@@ -79,6 +79,15 @@ describe('<CurrencyInput />', () => {
       assert.equal(input.get(0).value, '1,234.56');
     });
 
+    it('should prefix decimal only currency with 0', () => {
+      const component = mount(<CurrencyInput onChange={callback} />);
+      const input = component.find('input');
+
+      input.get(0).value = '.';
+      input.simulate('input');
+      assert.equal(input.get(0).value, '0.');
+    });
+
     // TODO skipped pending this issue/question: https://github.com/text-mask/text-mask/issues/372
     it.skip('should zero pad 1 decimal', () => {
       const component = mount(<CurrencyInput onChange={callback} value={1234.5} />);


### PR DESCRIPTION
This PR fixes an issue where currency inputs would not allow users to start entry with a decimal point.  The issue is already fixed in a PR to react-text-mask https://github.com/text-mask/text-mask/pull/542 so this PR takes the fix and adds it manually.

The patch can be removed once the PR above is merged and a new version of react-text-mask is released.