### PR TITLE
Generate a source map on build

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,6 +6,7 @@ const webpack = require('webpack');
  * Production webpack settings.
  */
 module.exports = {
+  devtool: 'source-map',
   entry: [
     path.resolve(__dirname, './src/index')
   ],
@@ -55,6 +56,7 @@ module.exports = {
       }
     }),
     new webpack.optimize.UglifyJsPlugin({
+      sourceMap: true,
       compressor: {
         warnings: false
       }


### PR DESCRIPTION
This will help with finding modules that contribute to the file size of the bundle.

To use this,

```
npm install source-map-explorer
./node_modules/.bin/source-map-explorer dist/bundle.js
```