### PR TITLE
rm: send undefined by default to prevent clearable UI for empty string

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "react": "~15.4.0",
     "react-dom": "~15.4.0",
     "react-fontawesome": "^1.4.0",
-    "react-select": "^1.0.0-rc.4",
+    "react-select": "^1.0.0-rc.5",
     "react-text-mask": "~5.0.2",
     "react-transition-group": "~1.1.3",
     "reactstrap": "4.8.0",

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -14,7 +14,6 @@ class Select extends Component {
   };
 
   static defaultProps = {
-    defaultValue: '',
     onChange: noop,
   };
 

--- a/stories/Address.js
+++ b/stories/Address.js
@@ -38,4 +38,3 @@ storiesOf('AddressInput', module)
       />
     </div>
   ));
-


### PR DESCRIPTION
PR does two things:
- upgrades `react-select` to `1.0.0-rc.5`
- fixes a bug where it looks like you can clear on a empty select field

Before:
![image](https://user-images.githubusercontent.com/7446202/28046023-8d4ddd72-6595-11e7-9280-9fb8efdc9de1.png)

After:
![image](https://user-images.githubusercontent.com/7446202/28046035-9d926ea0-6595-11e7-9403-c88938e0c903.png)
