### PR TITLE
Allow form row labels to be optional

### DIFF
--- a/src/components/FormRow.js
+++ b/src/components/FormRow.js
@@ -55,10 +55,12 @@ const FormRow = props => {
 
   return (
     <FormGroup row color={rowColor}>
-      <Label for={id} sm={labelWidth} size={size} className={labelAlignment}>
-        {label}
-        {required && label ? <span className="text-danger">&nbsp;*</span> : null}
-      </Label>
+      {label && (
+        <Label for={id} sm={labelWidth} size={size} className={labelAlignment}>
+          {label}
+          {required && label ? <span className="text-danger">&nbsp;*</span> : null}
+        </Label>
+      )}
       <Col sm={inputContainerWidth}>
         <Row>
           <Col {...width} >

--- a/test/components/FormRow.spec.js
+++ b/test/components/FormRow.spec.js
@@ -21,6 +21,11 @@ describe('<FormRow />', () => {
       assert.equal(label.render().text(), 'First Name');
     });
 
+    it('should not create a Label if the label prop is blank', () => {
+      const wrapper = shallow(<FormRow id="someID" size="sm" />);
+      assert.equal(wrapper.find(Label).length, 0);
+    });
+
     it('should wrap the input in a column', () => {
       const col = component.find(Col).at(0);
       assert.equal(col.prop('sm'), 9);


### PR DESCRIPTION
This PR allows users to pass `label={false}` to `FormRow` components, preventing the component from rendering a label.

This is useful for inputs within tables where the table header is used instead of a label.

For example in the screenshot below the `Account` column uses `FormRow` to make use of the field level error handling but does not need a label for each input.
![screen shot 2017-07-11 at 12 22 01 pm](https://user-images.githubusercontent.com/37422/28086317-73049d9a-6633-11e7-8ca8-0adf23a4b54e.png)
