### PR TITLE
Convert prop types to package

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "lodash.flow": "^3.5.0",
     "lodash.noop": "^3.0.1",
     "lodash.set": "^4.3.2",
+    "prop-types": "^15.5.10",
     "react-fontawesome": "^1.4.0",
     "react-select": "^1.0.0-rc.4",
     "react-text-mask": "~5.0.2",

--- a/src/components/AddressInput.js
+++ b/src/components/AddressInput.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { Col, Input, Row, Select, ValidatedFormGroup } from '../';
 import flow from 'lodash.flow';
@@ -111,20 +112,20 @@ class AddressInput extends Component {
 }
 
 export const addressPropType = {
-  address1: React.PropTypes.string,
-  address2: React.PropTypes.string,
-  city: React.PropTypes.string,
-  state: React.PropTypes.string,
-  postal: React.PropTypes.string,
-  countryCode: React.PropTypes.string,
+  address1: PropTypes.string,
+  address2: PropTypes.string,
+  city: PropTypes.string,
+  state: PropTypes.string,
+  postal: PropTypes.string,
+  countryCode: PropTypes.string,
 };
 
 AddressInput.propTypes = {
-  value: React.PropTypes.shape(addressPropType),
-  defaultValue: React.PropTypes.shape(addressPropType),
-  error: React.PropTypes.shape(addressPropType),
-  onChange: React.PropTypes.func,
-  disabled: React.PropTypes.bool
+  value: PropTypes.shape(addressPropType),
+  defaultValue: PropTypes.shape(addressPropType),
+  error: PropTypes.shape(addressPropType),
+  onChange: PropTypes.func,
+  disabled: PropTypes.bool
 };
 
 AddressInput.defaultProps = {

--- a/src/components/Alert.js
+++ b/src/components/Alert.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Icon } from '../';
 import { Alert } from 'reactstrap';
@@ -11,11 +12,11 @@ const ICON_MAP = {
 
 export default class AlertComponent extends React.Component {
   static propTypes = {
-    children: React.PropTypes.node,
-    color: React.PropTypes.string,
-    dismissible: React.PropTypes.bool,
-    icon: React.PropTypes.bool,
-    className: React.PropTypes.string
+    children: PropTypes.node,
+    color: PropTypes.string,
+    dismissible: PropTypes.bool,
+    icon: PropTypes.bool,
+    className: PropTypes.string
   }
 
   static defaultProps = {

--- a/src/components/BlockPanel.js
+++ b/src/components/BlockPanel.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classnames from 'classnames';
 import { Button, Card, CardBlock, CardHeader, CardTitle, Icon } from '../';
@@ -5,15 +6,15 @@ import { Button, Card, CardBlock, CardHeader, CardTitle, Icon } from '../';
 class BlockPanel extends Component {
 
   static propTypes = {
-    children: React.PropTypes.node,
-    controls: React.PropTypes.node,
-    className: React.PropTypes.string,
-    expandable: React.PropTypes.bool,
-    hideOnToggle: React.PropTypes.bool,
-    onEdit: React.PropTypes.func,
-    onToggle: React.PropTypes.func,
-    open: React.PropTypes.bool,
-    title: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.node]).isRequired
+    children: PropTypes.node,
+    controls: PropTypes.node,
+    className: PropTypes.string,
+    expandable: PropTypes.bool,
+    hideOnToggle: PropTypes.bool,
+    onEdit: PropTypes.func,
+    onToggle: PropTypes.func,
+    open: PropTypes.bool,
+    title: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired
   };
 
   static defaultProps = {

--- a/src/components/BoundForm.js
+++ b/src/components/BoundForm.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Form } from 'reactstrap';
 import noop from 'lodash.noop';
@@ -6,11 +7,11 @@ import cloneDeep from 'deep-clone-simple';
 
 class BoundForm extends React.Component {
   static propTypes = {
-    children: React.PropTypes.node,
-    errors: React.PropTypes.object,
-    object: React.PropTypes.object.isRequired,
-    onSubmit: React.PropTypes.func,
-    onChange: React.PropTypes.func
+    children: PropTypes.node,
+    errors: PropTypes.object,
+    object: PropTypes.object.isRequired,
+    onSubmit: PropTypes.func,
+    onChange: PropTypes.func
   };
 
   static defaultProps = {
@@ -20,9 +21,9 @@ class BoundForm extends React.Component {
   };
 
   static childContextTypes = {
-    value: React.PropTypes.object,
-    errors: React.PropTypes.object,
-    onChange: React.PropTypes.func
+    value: PropTypes.object,
+    errors: PropTypes.object,
+    onChange: PropTypes.func
   }
 
   constructor(props) {

--- a/src/components/BoundFormRow.js
+++ b/src/components/BoundFormRow.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import FormRow from './FormRow';
 
@@ -24,14 +25,14 @@ const BoundFormRow = (props, { value = {}, errors = {}, onChange }) => {
 };
 
 BoundFormRow.contextTypes = {
-  value: React.PropTypes.object,
-  errors: React.PropTypes.object,
-  onChange: React.PropTypes.func
+  value: PropTypes.object,
+  errors: PropTypes.object,
+  onChange: PropTypes.func
 };
 
 BoundFormRow.propTypes = {
-  name: React.PropTypes.string.isRequired,
-  onChange: React.PropTypes.func
+  name: PropTypes.string.isRequired,
+  onChange: PropTypes.func
 };
 
 BoundFormRow.defaultProps = {

--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { Table } from '../';
 import classnames from 'classnames';
@@ -39,12 +40,12 @@ const Day = ({ day, dateFormat, ...props }) => {
 class Calendar extends Component {
 
   static propTypes = {
-    className: React.PropTypes.string,
-    date: React.PropTypes.instanceOf(Date),
-    dateFormat: React.PropTypes.string,
-    dateVisible: React.PropTypes.func,
-    onSelect: React.PropTypes.func,
-    weekDayFormat: React.PropTypes.string
+    className: PropTypes.string,
+    date: PropTypes.instanceOf(Date),
+    dateFormat: PropTypes.string,
+    dateVisible: PropTypes.func,
+    onSelect: PropTypes.func,
+    weekDayFormat: PropTypes.string
   };
 
   static defaultProps = {

--- a/src/components/Callout.js
+++ b/src/components/Callout.js
@@ -1,14 +1,15 @@
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import styles from './Callout.scss';
 
 class Callout extends Component {
 
   static propTypes = {
-    children: React.PropTypes.node,
-    className: React.PropTypes.string,
-    color: React.PropTypes.string,
-    background: React.PropTypes.string,
-    placement: React.PropTypes.oneOf([
+    children: PropTypes.node,
+    className: PropTypes.string,
+    color: PropTypes.string,
+    background: PropTypes.string,
+    placement: PropTypes.oneOf([
       'top',
       'bottom',
       'left',

--- a/src/components/CheckboxBooleanInput.js
+++ b/src/components/CheckboxBooleanInput.js
@@ -1,11 +1,12 @@
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { FormGroup, Input, Label } from 'reactstrap';
 
 class CheckboxBooleanInput extends Component {
   static propTypes = {
-    checkboxLabel: React.PropTypes.node,
-    onChange: React.PropTypes.func,
-    value: React.PropTypes.bool
+    checkboxLabel: PropTypes.node,
+    onChange: PropTypes.func,
+    value: PropTypes.bool
   };
 
   render() {

--- a/src/components/CreditCardExpiration.js
+++ b/src/components/CreditCardExpiration.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { Col, Row } from 'reactstrap';
 import { Select } from '../';
 

--- a/src/components/CreditCardInput.js
+++ b/src/components/CreditCardInput.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import {
   Row, Col, PatternInput, ValidatedFormGroup,
   CreditCardExpiration, CreditCardNumber,

--- a/src/components/CreditCardNumber.js
+++ b/src/components/CreditCardNumber.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { Icon, InputGroup } from '../';
 import { Input, InputGroupAddon } from 'reactstrap';
 import CardValidator from 'card-validator';

--- a/src/components/CurrencyInput.js
+++ b/src/components/CurrencyInput.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import MaskedInput from 'react-text-mask';
 
 //

--- a/src/components/Datapair.js
+++ b/src/components/Datapair.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Col, Row } from 'reactstrap';
 
@@ -9,9 +10,9 @@ const Datapair = props => (
 );
 
 Datapair.propTypes = {
-  children: React.PropTypes.node,
-  label: React.PropTypes.string.isRequired,
-  value: React.PropTypes.string
+  children: PropTypes.node,
+  label: PropTypes.string.isRequired,
+  value: PropTypes.string
 };
 
 export default Datapair;

--- a/src/components/DateInput.js
+++ b/src/components/DateInput.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { Button, ButtonGroup, DropdownMenu, Icon, Input, InputGroupButton, InputGroup } from '../';
 import { Dropdown } from 'reactstrap';
@@ -48,23 +49,23 @@ function parseValue(defaultValue, dateFormat) {
 export default class DateInput extends Component {
 
   static propTypes = {
-    className: React.PropTypes.string,
-    dateVisible: React.PropTypes.func,
-    dateFormat: React.PropTypes.string,
-    defaultValue: React.PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.object
+    className: PropTypes.string,
+    dateVisible: PropTypes.func,
+    dateFormat: PropTypes.string,
+    defaultValue: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.object
     ]),
-    disabled: React.PropTypes.bool,
-    header: React.PropTypes.node,
-    footer: React.PropTypes.node,
-    keyboard: React.PropTypes.bool,
-    onBlur: React.PropTypes.func,
-    onChange: React.PropTypes.func,
-    showOnFocus: React.PropTypes.bool,
-    value: React.PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.object
+    disabled: PropTypes.bool,
+    header: PropTypes.node,
+    footer: PropTypes.node,
+    keyboard: PropTypes.bool,
+    onBlur: PropTypes.func,
+    onChange: PropTypes.func,
+    showOnFocus: PropTypes.bool,
+    value: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.object
     ])
     // TODO allow custom header/footer, header & day format?
   }

--- a/src/components/DeletedNote.js
+++ b/src/components/DeletedNote.js
@@ -1,10 +1,11 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Alert } from '../';
 
 class DeletedNote extends React.Component {
   static propTypes = {
-    note: React.PropTypes.object.isRequired,
-    onUndelete: React.PropTypes.func
+    note: PropTypes.object.isRequired,
+    onUndelete: PropTypes.func
   };
 
   render() {

--- a/src/components/EditableNote.js
+++ b/src/components/EditableNote.js
@@ -1,12 +1,13 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Button, ButtonToolbar, Card, CardBlock, Input } from '../';
 
 class EditableNote extends React.Component {
   static propTypes = {
-    note: React.PropTypes.object.isRequired,
-    onCancel: React.PropTypes.func.isRequired,
-    onChange: React.PropTypes.func.isRequired,
-    onSave: React.PropTypes.func.isRequired
+    note: PropTypes.object.isRequired,
+    onCancel: PropTypes.func.isRequired,
+    onChange: PropTypes.func.isRequired,
+    onSave: PropTypes.func.isRequired
   };
 
   render() {

--- a/src/components/ExpandableSection.js
+++ b/src/components/ExpandableSection.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { Icon } from '../';
 
@@ -38,8 +39,8 @@ class ExpandableSection extends Component {
 }
 
 ExpandableSection.propTypes = {
-  open: React.PropTypes.bool,
-  title: React.PropTypes.string.isRequired
+  open: PropTypes.bool,
+  title: PropTypes.string.isRequired
 };
 
 ExpandableSection.defaultProps = {

--- a/src/components/FeatureBanner.js
+++ b/src/components/FeatureBanner.js
@@ -1,13 +1,14 @@
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { Alert } from 'reactstrap';
 import styles from './FeatureBanner.scss';
 
 export default class FeatureBanner extends Component {
   static propTypes = {
-    alertText: React.PropTypes.string,
-    children: React.PropTypes.node,
-    subtitle: React.PropTypes.string.isRequired,
-    title: React.PropTypes.string.isRequired,
+    alertText: PropTypes.string,
+    children: PropTypes.node,
+    subtitle: PropTypes.string.isRequired,
+    title: PropTypes.string.isRequired,
   };
 
   static defaultProps = {

--- a/src/components/FileInput.js
+++ b/src/components/FileInput.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { Input } from 'reactstrap';
 
@@ -22,7 +23,7 @@ class FileInput extends Component {
 }
 
 FileInput.propTypes = {
-  onChange: React.PropTypes.func
+  onChange: PropTypes.func
 };
 
 export default FileInput;

--- a/src/components/FilterList.js
+++ b/src/components/FilterList.js
@@ -1,13 +1,14 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { LabelBadge } from '../';
 
 export default class FilterList extends React.Component {
 
   static propTypes = {
-    className: React.PropTypes.string,
-    filters: React.PropTypes.array.isRequired,
-    maxWidth: React.PropTypes.number,
-    onRemove: React.PropTypes.func
+    className: PropTypes.string,
+    filters: PropTypes.array.isRequired,
+    maxWidth: PropTypes.number,
+    onRemove: PropTypes.func
   }
 
   static defaultProps = {

--- a/src/components/FormRow.js
+++ b/src/components/FormRow.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { FormGroup, Input, Label, Col, Row, FormFeedback, FormText } from 'reactstrap';
 
@@ -83,21 +84,21 @@ const FormRow = props => {
 };
 
 FormRow.propTypes = {
-  label: React.PropTypes.string,
-  hint: React.PropTypes.string,
-  feedback: React.PropTypes.oneOfType([
-    React.PropTypes.string,
-    React.PropTypes.object
+  label: PropTypes.string,
+  hint: PropTypes.string,
+  feedback: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object
   ]),
-  required: React.PropTypes.bool,
-  type: React.PropTypes.oneOfType([
-    React.PropTypes.string,
-    React.PropTypes.element,
-    React.PropTypes.func
+  required: PropTypes.bool,
+  type: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.element,
+    PropTypes.func
   ]),
-  inline: React.PropTypes.bool,
-  stacked: React.PropTypes.bool,
-  width: React.PropTypes.object
+  inline: PropTypes.bool,
+  stacked: PropTypes.bool,
+  width: PropTypes.object
 };
 
 FormRow.defaultProps = {

--- a/src/components/HasManyFields.js
+++ b/src/components/HasManyFields.js
@@ -1,5 +1,6 @@
 import noop from 'lodash.noop';
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
 
 import HasManyFieldsAdd from './HasManyFieldsAdd';

--- a/src/components/HasManyFieldsAdd.js
+++ b/src/components/HasManyFieldsAdd.js
@@ -1,4 +1,5 @@
 import classNames from 'classnames';
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Button } from 'reactstrap';
 
@@ -16,9 +17,9 @@ const HasManyFieldsAdd = ({ children, className, ...props }) => {
 };
 
 HasManyFieldsAdd.propTypes = {
-  className: React.PropTypes.string,
-  children: React.PropTypes.node.isRequired,
-  disabled: React.PropTypes.bool
+  className: PropTypes.string,
+  children: PropTypes.node.isRequired,
+  disabled: PropTypes.bool
 };
 
 export default HasManyFieldsAdd;

--- a/src/components/HasManyFieldsRow.js
+++ b/src/components/HasManyFieldsRow.js
@@ -1,4 +1,5 @@
 import noop from 'lodash.noop';
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Button, Col, Row } from 'reactstrap';
 
@@ -21,9 +22,9 @@ const HasManyFieldsRow = ({ children, onDelete, disabled }) => (
 );
 
 HasManyFieldsRow.propTypes = {
-  children: React.PropTypes.node.isRequired,
-  onDelete: React.PropTypes.func,
-  disabled: React.PropTypes.bool
+  children: PropTypes.node.isRequired,
+  onDelete: PropTypes.func,
+  disabled: PropTypes.bool
 };
 
 HasManyFieldsRow.defaultProps = {

--- a/src/components/HelpBubble.js
+++ b/src/components/HelpBubble.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Icon } from '../';
 import { Popover, PopoverTitle, PopoverContent } from 'reactstrap';
@@ -48,9 +49,9 @@ class HelpBubble extends React.Component {
 }
 
 HelpBubble.propTypes = {
-  title: React.PropTypes.string.isRequired,
-  children: React.PropTypes.node,
-  className: React.PropTypes.any
+  title: PropTypes.string.isRequired,
+  children: PropTypes.node,
+  className: PropTypes.any
 };
 
 export default HelpBubble;

--- a/src/components/InfoBox.js
+++ b/src/components/InfoBox.js
@@ -1,15 +1,16 @@
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { Icon } from '../';
 import styles from './InfoBox.scss';
 
 export default class InfoBox extends Component {
   static propTypes = {
-    className: React.PropTypes.string,
-    color: React.PropTypes.string,
-    children: React.PropTypes.node,
-    icon: React.PropTypes.string,
-    title: React.PropTypes.string,
-    vertical: React.PropTypes.bool
+    className: PropTypes.string,
+    color: PropTypes.string,
+    children: PropTypes.node,
+    icon: PropTypes.string,
+    title: PropTypes.string,
+    vertical: PropTypes.bool
   };
 
   static defaultProps = {

--- a/src/components/LabelBadge.js
+++ b/src/components/LabelBadge.js
@@ -1,15 +1,16 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import styles from './LabelBadge.scss';
 
 export default class LabelBadge extends React.Component {
 
   static propTypes = {
-    className: React.PropTypes.string,
-    label: React.PropTypes.string,
-    maxWidth: React.PropTypes.number,
-    onRemove: React.PropTypes.func,
-    removable: React.PropTypes.bool,
-    value: React.PropTypes.string.isRequired
+    className: PropTypes.string,
+    label: PropTypes.string,
+    maxWidth: PropTypes.number,
+    onRemove: PropTypes.func,
+    removable: PropTypes.bool,
+    value: PropTypes.string.isRequired
   }
 
   static defaultProps = {

--- a/src/components/Note.js
+++ b/src/components/Note.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Button, Card, CardBlock, CardHeader, CardText, Flag } from '../';
 import DeletedNote from './DeletedNote.js';
@@ -12,14 +13,14 @@ class Note extends React.Component {
   static displayName = 'Note';
 
   static propTypes = {
-    className: React.PropTypes.string,
-    note: React.PropTypes.object,
-    onCancel: React.PropTypes.func,
-    onChange: React.PropTypes.func,
-    onDelete: React.PropTypes.func,
-    onEdit: React.PropTypes.func,
-    onSave: React.PropTypes.func,
-    onUndelete: React.PropTypes.func
+    className: PropTypes.string,
+    note: PropTypes.object,
+    onCancel: PropTypes.func,
+    onChange: PropTypes.func,
+    onDelete: PropTypes.func,
+    onEdit: PropTypes.func,
+    onSave: PropTypes.func,
+    onUndelete: PropTypes.func
   };
 
   static defaultProps = {

--- a/src/components/Notes.js
+++ b/src/components/Notes.js
@@ -1,19 +1,20 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { HelpBubble, Row, Col, Button, Icon, Note } from '../';
 
 export default class Notes extends React.Component {
 
   static propTypes = {
-    className: React.PropTypes.string,
-    onAdd: React.PropTypes.func,
-    onCancel: React.PropTypes.func,
-    onChange: React.PropTypes.func,
-    onDelete: React.PropTypes.func,
-    onDownload: React.PropTypes.func,
-    onEdit: React.PropTypes.func,
-    onSave: React.PropTypes.func,
-    onUndelete: React.PropTypes.func,
-    notes: React.PropTypes.array,
+    className: PropTypes.string,
+    onAdd: PropTypes.func,
+    onCancel: PropTypes.func,
+    onChange: PropTypes.func,
+    onDelete: PropTypes.func,
+    onDownload: PropTypes.func,
+    onEdit: PropTypes.func,
+    onSave: PropTypes.func,
+    onUndelete: PropTypes.func,
+    notes: PropTypes.array,
   }
 
   static defaultProps = {

--- a/src/components/Paginator.js
+++ b/src/components/Paginator.js
@@ -1,4 +1,5 @@
 import Page from './Paginator/Page';
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import ShortcutLink from './Paginator/ShortcutLink';
 import State from './Paginator/State';
@@ -13,11 +14,11 @@ const DEFAULT_PER_PAGE = 20;
  */
 export default class Paginator extends Component {
   static propTypes = {
-    currentPage: React.PropTypes.number.isRequired,
-    onClick: React.PropTypes.func.isRequired,
-    perPage: React.PropTypes.number,
-    size: React.PropTypes.oneOf(['sm', 'lg']),
-    totalItems: React.PropTypes.number.isRequired,
+    currentPage: PropTypes.number.isRequired,
+    onClick: PropTypes.func.isRequired,
+    perPage: PropTypes.number,
+    size: PropTypes.oneOf(['sm', 'lg']),
+    totalItems: PropTypes.number.isRequired,
   }
 
   static defaultProps = {

--- a/src/components/Paginator/Page.js
+++ b/src/components/Paginator/Page.js
@@ -1,16 +1,17 @@
-import React, { Component } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { PaginationItem, PaginationLink } from '../../';
 
 /**
  * A clickable link to a page in the pagination bar
  */
-export default class Page extends Component {
+export default class Page extends React.Component {
   static displayName = 'Page';
 
   static propTypes = {
-    current: React.PropTypes.bool.isRequired,
-    onClick: React.PropTypes.func.isRequired,
-    page: React.PropTypes.number.isRequired,
+    current: PropTypes.bool.isRequired,
+    onClick: PropTypes.func.isRequired,
+    page: PropTypes.number.isRequired,
   }
 
   onClick = event => {

--- a/src/components/Paginator/ShortcutLink.js
+++ b/src/components/Paginator/ShortcutLink.js
@@ -1,15 +1,16 @@
-import React, { Component } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { PaginationItem, PaginationLink } from '../../';
 
 /**
  * A clickable link to the first/previous/next/last page in the pagination bar
  */
-export default class ShortcutLink extends Component {
+export default class ShortcutLink extends React.Component {
   static propTypes = {
-    children: React.PropTypes.node,
-    name: React.PropTypes.string.isRequired,
-    onClick: React.PropTypes.func.isRequired,
-    page: React.PropTypes.number.isRequired,
+    children: PropTypes.node,
+    name: PropTypes.string.isRequired,
+    onClick: PropTypes.func.isRequired,
+    page: PropTypes.number.isRequired,
   }
 
   onClick = event => {

--- a/src/components/Paginator/Summary.js
+++ b/src/components/Paginator/Summary.js
@@ -1,16 +1,17 @@
-import React, { Component } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 /**
  * A text summary of the current pagination state
  */
-export default class Summary extends Component {
+export default class Summary extends React.Component {
   static displayName = 'Summary';
 
   static propTypes = {
-    className: React.PropTypes.string,
-    from: React.PropTypes.number.isRequired,
-    to: React.PropTypes.number.isRequired,
-    totalItems: React.PropTypes.number.isRequired,
+    className: PropTypes.string,
+    from: PropTypes.number.isRequired,
+    to: PropTypes.number.isRequired,
+    totalItems: PropTypes.number.isRequired,
   }
 
   static defaultProps = {

--- a/src/components/PatternInput.js
+++ b/src/components/PatternInput.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { Input } from 'reactstrap';
 
 export default class PatternInput extends Component {

--- a/src/components/Popover.js
+++ b/src/components/Popover.js
@@ -1,9 +1,10 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Popover } from 'reactstrap';
 
 Popover.propTypes = {
   ...Popover.propTypes,
-  placement: React.PropTypes.oneOf(['top', 'bottom', 'left', 'right']) // Overrides reactstrap's unsupported options.
+  placement: PropTypes.oneOf(['top', 'bottom', 'left', 'right']) // Overrides reactstrap's unsupported options.
 };
 
 export default Popover;

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import ReactSelect from 'react-select';
 import noop from 'lodash.noop';
@@ -7,10 +8,10 @@ import './Select.scss';
 
 class Select extends Component {
   static propTypes = {
-    defaultValue: React.PropTypes.any,
-    loadOptions: React.PropTypes.func,
-    onChange: React.PropTypes.func,
-    value: React.PropTypes.any,
+    defaultValue: PropTypes.any,
+    loadOptions: PropTypes.func,
+    onChange: PropTypes.func,
+    value: PropTypes.any,
   };
 
   static defaultProps = {

--- a/src/components/Spinner.js
+++ b/src/components/Spinner.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import styles from './Spinner.scss';
 import classnames from 'classnames';
@@ -12,8 +13,8 @@ const Spinner = props => (
 );
 
 Spinner.propTypes = {
-  className: React.PropTypes.string,
-  style: React.PropTypes.object,
+  className: PropTypes.string,
+  style: PropTypes.object,
   // TODO add size prop in lieu of style
 };
 

--- a/src/components/Steps.js
+++ b/src/components/Steps.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 import Icon from './Icon.js';
@@ -46,9 +47,9 @@ const Steps = ({ complete, step, steps }) => {
 };
 
 Steps.propTypes = {
-  step: React.PropTypes.number,
-  steps: React.PropTypes.array.isRequired,
-  complete: React.PropTypes.bool
+  step: PropTypes.number,
+  steps: PropTypes.array.isRequired,
+  complete: PropTypes.bool
 };
 
 export default Steps;

--- a/src/components/SummaryBox.js
+++ b/src/components/SummaryBox.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { CardGroup } from '../';
 import SummaryBoxItem from './SummaryBoxItem.js';
@@ -11,7 +12,7 @@ const SummaryBox = (props) => (
 );
 
 SummaryBox.propTypes = {
-  items: React.PropTypes.array
+  items: PropTypes.array
 };
 
 export default SummaryBox;

--- a/src/components/SummaryBoxItem.js
+++ b/src/components/SummaryBoxItem.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Card, CardBlock } from '../';
 
@@ -11,8 +12,8 @@ const SummaryBoxItem = (props) => (
 );
 
 SummaryBoxItem.propTypes = {
-  label: React.PropTypes.string,
-  value: React.PropTypes.string // TODO support links
+  label: PropTypes.string,
+  value: PropTypes.string // TODO support links
 };
 
 SummaryBoxItem.defaultProps = {

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { Table } from 'reactstrap';
 
 class TableComponent extends Component {

--- a/src/components/Tooltip.js
+++ b/src/components/Tooltip.js
@@ -1,9 +1,10 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Tooltip as InnerTooltip } from 'reactstrap';
 
 export default class Tooltip extends React.Component {
   static propTypes = {
-    isOpen: React.PropTypes.bool
+    isOpen: PropTypes.bool
   };
 
   static defaultProps = {

--- a/src/components/ValidatedFormGroup.js
+++ b/src/components/ValidatedFormGroup.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { FormFeedback, FormGroup } from '../';
 
 const ValidatedFormGroup = ({ children, error, label, labelTag: Tag, ...props }) => (

--- a/src/components/Waiting.js
+++ b/src/components/Waiting.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classnames from 'classnames';
 import Modal from './Modal';
@@ -12,11 +13,11 @@ const noop = () => {};
  */
 export default class Waiting extends Component {
   static propTypes = {
-    backdrop: React.PropTypes.bool,
-    children: React.PropTypes.node,
-    className: React.PropTypes.string,
-    isOpen: React.PropTypes.bool,
-    title: React.PropTypes.string,
+    backdrop: PropTypes.bool,
+    children: PropTypes.node,
+    className: PropTypes.string,
+    isOpen: PropTypes.bool,
+    title: PropTypes.string,
   }
 
   static defaultProps = {

--- a/src/components/icon/FontAwesomeAPM.js
+++ b/src/components/icon/FontAwesomeAPM.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 export const srOnlyStyle = {
   position: 'absolute',
@@ -35,20 +36,20 @@ export const srOnlyStyle = {
 export default class FontAwesomeAPM extends React.Component {
 
   static propTypes = {
-    ariaLabel: React.PropTypes.string,
-    border: React.PropTypes.bool,
-    className: React.PropTypes.string,
-    cssModule: React.PropTypes.object,
-    fixedWidth: React.PropTypes.bool,
-    flip: React.PropTypes.oneOf(['horizontal', 'vertical']),
-    inverse: React.PropTypes.bool,
-    name: React.PropTypes.string.isRequired,
-    pulse: React.PropTypes.bool,
-    rotate: React.PropTypes.oneOf([90, 180, 270]),
-    size: React.PropTypes.oneOf(['lg', '2x', '3x', '4x', '5x']),
-    spin: React.PropTypes.bool,
-    stack: React.PropTypes.oneOf(['1x', '2x']),
-    tag: React.PropTypes.string,
+    ariaLabel: PropTypes.string,
+    border: PropTypes.bool,
+    className: PropTypes.string,
+    cssModule: PropTypes.object,
+    fixedWidth: PropTypes.bool,
+    flip: PropTypes.oneOf(['horizontal', 'vertical']),
+    inverse: PropTypes.bool,
+    name: PropTypes.string.isRequired,
+    pulse: PropTypes.bool,
+    rotate: PropTypes.oneOf([90, 180, 270]),
+    size: PropTypes.oneOf(['lg', '2x', '3x', '4x', '5x']),
+    spin: PropTypes.bool,
+    stack: PropTypes.oneOf(['1x', '2x']),
+    tag: PropTypes.string,
   }
 
   render() {


### PR DESCRIPTION
This will use the `prop-types` package instead of `React.PropTypes`, as the latter has been deprecated as of React 15.6.