### PR TITLE
React has no named imports

### DIFF
--- a/src/components/AddressInput.js
+++ b/src/components/AddressInput.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React from 'react';
 import { Col, Input, Row, Select, ValidatedFormGroup } from '../';
 import flow from 'lodash.flow';
 import noop from 'lodash.noop';
@@ -15,7 +15,7 @@ const US_STATES = states.map(state => ({
 
 const readEvent = e => ({ [e.target.name]: e.target.value });
 
-class AddressInput extends Component {
+class AddressInput extends React.Component {
   onChange = update => {
     this.props.onChange({ ...this.props.value, ...update });
   }

--- a/src/components/BlockPanel.js
+++ b/src/components/BlockPanel.js
@@ -1,9 +1,9 @@
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React from 'react';
 import classnames from 'classnames';
 import { Button, Card, CardBlock, CardHeader, CardTitle, Icon } from '../';
 
-class BlockPanel extends Component {
+class BlockPanel extends React.Component {
 
   static propTypes = {
     children: PropTypes.node,

--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React from 'react';
 import { Table } from '../';
 import classnames from 'classnames';
 import addWeeks from 'date-fns/add_weeks';
@@ -37,7 +37,7 @@ const Day = ({ day, dateFormat, ...props }) => {
   );
 };
 
-class Calendar extends Component {
+class Calendar extends React.Component {
 
   static propTypes = {
     className: PropTypes.string,

--- a/src/components/Callout.js
+++ b/src/components/Callout.js
@@ -1,8 +1,8 @@
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React from 'react';
 import styles from './Callout.scss';
 
-class Callout extends Component {
+class Callout extends React.Component {
 
   static propTypes = {
     children: PropTypes.node,

--- a/src/components/CheckboxBooleanInput.js
+++ b/src/components/CheckboxBooleanInput.js
@@ -1,8 +1,8 @@
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React from 'react';
 import { FormGroup, Input, Label } from 'reactstrap';
 
-class CheckboxBooleanInput extends Component {
+class CheckboxBooleanInput extends React.Component {
   static propTypes = {
     checkboxLabel: PropTypes.node,
     onChange: PropTypes.func,

--- a/src/components/CreditCardExpiration.js
+++ b/src/components/CreditCardExpiration.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React from 'react';
 import { Col, Row } from 'reactstrap';
 import { Select } from '../';
 
@@ -16,7 +16,7 @@ const monthOptions = MONTHS.map((label, index) => ({ label, value: index + 1 }))
 // eslint-disable-next-line arrow-body-style
 const yearsOptions = YEARS.map(year => ({ label: year, value: year }));
 
-export default class CreditCardExpiration extends Component {
+export default class CreditCardExpiration extends React.Component {
   onMonthSelection = (option) => {
     const month = option && option.value || CreditCardExpiration.defaultProps.month;
     this.props.onChange({ month, year: this.props.year });

--- a/src/components/CreditCardInput.js
+++ b/src/components/CreditCardInput.js
@@ -1,11 +1,11 @@
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React from 'react';
 import {
   Row, Col, PatternInput, ValidatedFormGroup,
   CreditCardExpiration, CreditCardNumber,
 } from '../';
 
-export default class CreditCardInput extends Component {
+export default class CreditCardInput extends React.Component {
   handleCardCVVChange = (event, { value, isValid }) => {
     this.props.onChange({ cardCVV: value, cardCVVIsValid: isValid });
   }

--- a/src/components/CreditCardNumber.js
+++ b/src/components/CreditCardNumber.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React from 'react';
 import { Icon, InputGroup } from '../';
 import { Input, InputGroupAddon } from 'reactstrap';
 import CardValidator from 'card-validator';
@@ -23,7 +23,7 @@ function includes(array, value) {
   return Array.isArray(array) && array.indexOf(value) !== -1;
 }
 
-export default class CreditCardNumber extends Component {
+export default class CreditCardNumber extends React.Component {
   constructor(props) {
     super(props);
     this.state = { value: '', cardType: undefined };

--- a/src/components/DateInput.js
+++ b/src/components/DateInput.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React from 'react';
 import { Button, ButtonGroup, DropdownMenu, Icon, Input, InputGroupButton, InputGroup } from '../';
 import { Dropdown } from 'reactstrap';
 import Calendar from './Calendar.js';
@@ -46,7 +46,7 @@ function parseValue(defaultValue, dateFormat) {
   return date;
 }
 
-export default class DateInput extends Component {
+export default class DateInput extends React.Component {
 
   static propTypes = {
     className: PropTypes.string,

--- a/src/components/ExpandableSection.js
+++ b/src/components/ExpandableSection.js
@@ -1,10 +1,10 @@
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React from 'react';
 import { Icon } from '../';
 
 import styles from './ExpandableSection.scss';
 
-class ExpandableSection extends Component {
+class ExpandableSection extends React.Component {
 
   constructor(props) {
     super(props);

--- a/src/components/FeatureBanner.js
+++ b/src/components/FeatureBanner.js
@@ -1,9 +1,9 @@
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React from 'react';
 import { Alert } from 'reactstrap';
 import styles from './FeatureBanner.scss';
 
-export default class FeatureBanner extends Component {
+export default class FeatureBanner extends React.Component {
   static propTypes = {
     alertText: PropTypes.string,
     children: PropTypes.node,

--- a/src/components/FileInput.js
+++ b/src/components/FileInput.js
@@ -1,8 +1,8 @@
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React from 'react';
 import { Input } from 'reactstrap';
 
-class FileInput extends Component {
+class FileInput extends React.Component {
   onChange = changeEvent => {
     if (this.props.onChange) {
       this.props.onChange(changeEvent.target.files);

--- a/src/components/HasManyFields.js
+++ b/src/components/HasManyFields.js
@@ -1,12 +1,12 @@
 import noop from 'lodash.noop';
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React from 'react';
 import ReactDOM from 'react-dom';
 
 import HasManyFieldsAdd from './HasManyFieldsAdd';
 import HasManyFieldsRow from './HasManyFieldsRow';
 
-class HasManyFields extends Component {
+class HasManyFields extends React.Component {
   static propTypes = {
     blank: PropTypes.any,
     defaultValue: PropTypes.array,

--- a/src/components/InfoBox.js
+++ b/src/components/InfoBox.js
@@ -1,9 +1,9 @@
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React from 'react';
 import { Icon } from '../';
 import styles from './InfoBox.scss';
 
-export default class InfoBox extends Component {
+export default class InfoBox extends React.Component {
   static propTypes = {
     className: PropTypes.string,
     color: PropTypes.string,

--- a/src/components/Paginator.js
+++ b/src/components/Paginator.js
@@ -1,6 +1,6 @@
 import Page from './Paginator/Page';
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React from 'react';
 import ShortcutLink from './Paginator/ShortcutLink';
 import State from './Paginator/State';
 import Summary from './Paginator/Summary';
@@ -12,7 +12,7 @@ const DEFAULT_PER_PAGE = 20;
  * A component that generates a set of links that can be used for pagination.  Link selection is
  * communicated via the `onClick` callback.
  */
-export default class Paginator extends Component {
+export default class Paginator extends React.Component {
   static propTypes = {
     currentPage: PropTypes.number.isRequired,
     onClick: PropTypes.func.isRequired,

--- a/src/components/PatternInput.js
+++ b/src/components/PatternInput.js
@@ -1,8 +1,8 @@
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React from 'react';
 import { Input } from 'reactstrap';
 
-export default class PatternInput extends Component {
+export default class PatternInput extends React.Component {
   constructor(props) {
     super(props);
     const isValid = props.pattern.exec(props.value || '') !== null;

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -1,12 +1,12 @@
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React from 'react';
 import ReactSelect from 'react-select';
 import noop from 'lodash.noop';
 
 // Disables CSS modules to import as global:
 import './Select.scss';
 
-class Select extends Component {
+class Select extends React.Component {
   static propTypes = {
     defaultValue: PropTypes.any,
     loadOptions: PropTypes.func,

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -1,8 +1,8 @@
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React from 'react';
 import { Table } from 'reactstrap';
 
-class TableComponent extends Component {
+class TableComponent extends React.Component {
   static displayName = 'Table';
   static propTypes = {
     size: PropTypes.string,

--- a/src/components/Waiting.js
+++ b/src/components/Waiting.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React from 'react';
 import classnames from 'classnames';
 import Modal from './Modal';
 import Spinner from './Spinner';
@@ -11,7 +11,7 @@ const noop = () => {};
 /**
  * A 'Waiting' indicator for unknown durations. See https://qa.qa.appfolio.com/gears/waiting
  */
-export default class Waiting extends Component {
+export default class Waiting extends React.Component {
   static propTypes = {
     backdrop: PropTypes.bool,
     children: PropTypes.node,

--- a/src/components/datemonth/DateMonth.js
+++ b/src/components/datemonth/DateMonth.js
@@ -2,7 +2,7 @@ import { Button, ButtonGroup, Col, Input,
          InputGroupButton, InputGroup, Row } from 'reactstrap';
 import { Dropdown, DropdownMenu, Icon } from '../../';
 import Label from './DateMonthLabel.js';
-import React, { Component } from 'react';
+import React from 'react';
 import fecha from 'fecha';
 import path from './path.js';
 import styles from './DateMonth.scss';
@@ -20,7 +20,7 @@ function range(start, end) {
 
 // TODO refactor this component to match DateInput behavior, e.g. a new "DropdownInput" component.
 
-export default class DateMonth extends Component {
+export default class DateMonth extends React.Component {
   constructor(props) {
     super(props);
 


### PR DESCRIPTION
React only has a default export. It does not have named exports. Webpack is fine with this, Rollup is not.

This PR removes all named imports from `'react'` and instead uses the React object directly.