### PR TITLE
ps - Do not import from index

### DIFF
--- a/src/components/AddressInput.js
+++ b/src/components/AddressInput.js
@@ -1,8 +1,11 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Col, Input, Row, Select, ValidatedFormGroup } from '../';
+import { Col, Input, Row } from 'reactstrap';
 import flow from 'lodash.flow';
 import noop from 'lodash.noop';
+
+import Select from './Select';
+import ValidatedFormGroup from './ValidatedFormGroup';
 
 // TODO Dynamic states based on country:
 import states from './address/USStates.js';

--- a/src/components/Alert.js
+++ b/src/components/Alert.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Icon } from '../';
 import { Alert } from 'reactstrap';
+import Icon from './Icon';
 
 const ICON_MAP = {
   warning: 'exclamation-circle',

--- a/src/components/BlockPanel.js
+++ b/src/components/BlockPanel.js
@@ -1,7 +1,14 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
-import { Button, Card, CardBlock, CardHeader, CardTitle, Icon } from '../';
+import {
+  Button,
+  Card,
+  CardBlock,
+  CardHeader,
+  CardTitle
+} from 'reactstrap';
+import Icon from './Icon';
 
 class BlockPanel extends React.Component {
 

--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Table } from '../';
+import { Table } from 'reactstrap';
 import classnames from 'classnames';
 import addWeeks from 'date-fns/add_weeks';
 import eachDay from 'date-fns/each_day';

--- a/src/components/CreditCardExpiration.js
+++ b/src/components/CreditCardExpiration.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Col, Row } from 'reactstrap';
-import { Select } from '../';
+import Select from './Select';
 
 const today = new Date();
 const MONTHS = [

--- a/src/components/CreditCardInput.js
+++ b/src/components/CreditCardInput.js
@@ -1,9 +1,14 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {
-  Row, Col, PatternInput, ValidatedFormGroup,
-  CreditCardExpiration, CreditCardNumber,
-} from '../';
+  Row,
+  Col
+} from 'reactstrap';
+import PatternInput from './PatternInput';
+import ValidatedFormGroup from './ValidatedFormGroup';
+import CreditCardExpiration from './CreditCardExpiration';
+import CreditCardNumber from './CreditCardNumber.js';
+
 
 export default class CreditCardInput extends React.Component {
   handleCardCVVChange = (event, { value, isValid }) => {

--- a/src/components/CreditCardNumber.js
+++ b/src/components/CreditCardNumber.js
@@ -1,9 +1,9 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Icon, InputGroup } from '../';
-import { Input, InputGroupAddon } from 'reactstrap';
+import { Input, InputGroup, InputGroupAddon } from 'reactstrap';
 import CardValidator from 'card-validator';
 import cardTypeInfo from 'credit-card-type';
+import Icon from './Icon';
 
 const { number } = CardValidator;
 

--- a/src/components/DateInput.js
+++ b/src/components/DateInput.js
@@ -1,8 +1,14 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Button, ButtonGroup, DropdownMenu, Icon, Input, InputGroupButton, InputGroup } from '../';
-import { Dropdown } from 'reactstrap';
-import Calendar from './Calendar.js';
+import {
+  Button,
+  ButtonGroup,
+  Dropdown,
+  DropdownMenu,
+  Input,
+  InputGroupButton,
+  InputGroup
+} from 'reactstrap';
 import addDays from 'date-fns/add_days';
 import addMonths from 'date-fns/add_months';
 import addWeeks from 'date-fns/add_weeks';
@@ -10,6 +16,8 @@ import addYears from 'date-fns/add_years';
 import isValid from 'date-fns/is_valid';
 import Fecha from 'fecha'; // TODO replace with date-fns/parse after v2 is released
 import format from 'date-fns/format';
+import Icon from './Icon';
+import Calendar from './Calendar.js';
 
 const { parse } = Fecha;
 

--- a/src/components/DeletedNote.js
+++ b/src/components/DeletedNote.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Alert } from '../';
+import Alert from './Alert';
 
 class DeletedNote extends React.Component {
   static propTypes = {

--- a/src/components/EditableNote.js
+++ b/src/components/EditableNote.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Button, ButtonToolbar, Card, CardBlock, Input } from '../';
+import { Button, ButtonToolbar, Card, CardBlock, Input } from 'reactstrap';
 
 class EditableNote extends React.Component {
   static propTypes = {

--- a/src/components/ExpandableSection.js
+++ b/src/components/ExpandableSection.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Icon } from '../';
+import Icon from './Icon';
 
 import styles from './ExpandableSection.scss';
 

--- a/src/components/FilterList.js
+++ b/src/components/FilterList.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { LabelBadge } from '../';
+import LabelBadge from './LabelBadge';
 
 export default class FilterList extends React.Component {
 

--- a/src/components/HelpBubble.js
+++ b/src/components/HelpBubble.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Icon } from '../';
+import Icon from './Icon';
 import { Popover, PopoverTitle, PopoverContent } from 'reactstrap';
 
 let count = 0;

--- a/src/components/InfoBox.js
+++ b/src/components/InfoBox.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Icon } from '../';
+import Icon from './Icon';
 import styles from './InfoBox.scss';
 
 export default class InfoBox extends React.Component {

--- a/src/components/Note.js
+++ b/src/components/Note.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Button, Card, CardBlock, CardHeader, CardText, Flag } from '../';
+import { Button, Card, CardBlock, CardHeader, CardText, Badge } from 'reactstrap';
 import DeletedNote from './DeletedNote.js';
 import EditableNote from './EditableNote.js';
 
@@ -49,7 +49,7 @@ class Note extends React.Component {
             /> :
             <Card color="info" outline>
               <CardHeader className="d-flex justify-content-start p-2 bg-info">
-                {edited ? <span ref="edited"><Flag color="primary text-uppercase mr-2">Edited</Flag></span> : null}
+                {edited ? <span ref="edited"><Badge color="primary text-uppercase mr-2">Edited</Badge></span> : null}
                 <span className="text-muted">
                   <span className="hidden-xs-down">
                     {edited ? 'Last edited' : 'Posted'} {from ? <span ref="from">by {from}</span> : ' '} on <span ref="date">{dateFormat(date, 'ddd, MMMM D, YYYY "at" h:mm A')}</span>

--- a/src/components/Notes.js
+++ b/src/components/Notes.js
@@ -1,6 +1,9 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { HelpBubble, Row, Col, Button, Icon, Note } from '../';
+import { Row, Col, Button } from 'reactstrap';
+import HelpBubble from './HelpBubble';
+import Icon from './Icon';
+import Note from './Note';
 
 export default class Notes extends React.Component {
 

--- a/src/components/Paginator.js
+++ b/src/components/Paginator.js
@@ -1,10 +1,11 @@
 import Page from './Paginator/Page';
 import PropTypes from 'prop-types';
 import React from 'react';
+import { Pagination, Row } from 'reactstrap';
 import ShortcutLink from './Paginator/ShortcutLink';
 import State from './Paginator/State';
 import Summary from './Paginator/Summary';
-import { Icon, Pagination, Row } from '../';
+import Icon from './Icon';
 
 const DEFAULT_PER_PAGE = 20;
 

--- a/src/components/Paginator/Page.js
+++ b/src/components/Paginator/Page.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { PaginationItem, PaginationLink } from '../../';
+import { PaginationItem, PaginationLink } from 'reactstrap';
 
 /**
  * A clickable link to a page in the pagination bar

--- a/src/components/Paginator/ShortcutLink.js
+++ b/src/components/Paginator/ShortcutLink.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { PaginationItem, PaginationLink } from '../../';
+import { PaginationItem, PaginationLink } from 'reactstrap';
 
 /**
  * A clickable link to the first/previous/next/last page in the pagination bar

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -1,7 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import ReactSelect from 'react-select-plus';
-import { Close, Icon } from '../';
+import Close from './Close';
+import Icon from './Icon';
 import noop from 'lodash.noop';
 import Option from './SelectOption.js';
 

--- a/src/components/SummaryBox.js
+++ b/src/components/SummaryBox.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { CardGroup } from '../';
+import { CardGroup } from 'reactstrap';
 import SummaryBoxItem from './SummaryBoxItem.js';
 
 const SummaryBox = (props) => (

--- a/src/components/SummaryBoxItem.js
+++ b/src/components/SummaryBoxItem.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Card, CardBlock } from '../';
+import { Card, CardBlock } from 'reactstrap';
 
 const SummaryBoxItem = (props) => (
   <Card color="secondary" outline className="rounded-0">

--- a/src/components/ValidatedFormGroup.js
+++ b/src/components/ValidatedFormGroup.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { FormFeedback, FormGroup } from '../';
+import { FormFeedback, FormGroup } from 'reactstrap';
 
 const ValidatedFormGroup = ({ children, error, label, labelTag: Tag, ...props }) => (
   <FormGroup color={error && 'danger'} {...props}>

--- a/src/components/datemonth/DateMonth.js
+++ b/src/components/datemonth/DateMonth.js
@@ -1,6 +1,15 @@
-import { Button, ButtonGroup, Col, Input,
-         InputGroupButton, InputGroup, Row } from 'reactstrap';
-import { Dropdown, DropdownMenu, Icon } from '../../';
+import {
+  Button,
+  ButtonGroup,
+  Col,
+  Dropdown,
+  DropdownMenu,
+  Input,
+  InputGroupButton,
+  InputGroup,
+  Row
+} from 'reactstrap';
+import Icon from '../Icon';
 import Label from './DateMonthLabel.js';
 import React from 'react';
 import fecha from 'fecha';


### PR DESCRIPTION
This updates all imports in components from importing required component directly instead of going via index.js.

This will make it possible to directly import individual components without pulling in all of React Gears.