### PR TITLE
mj - allow other props to be passed through to checkbox, such as `disabled`

### DIFF
--- a/src/components/CheckboxBooleanInput.js
+++ b/src/components/CheckboxBooleanInput.js
@@ -12,17 +12,22 @@ class CheckboxBooleanInput extends React.Component {
   };
 
   render() {
-    const { checkboxLabel, onChange, value } = this.props;
+    const { checkboxLabel, onChange, value, ...inputProps } = this.props;
 
     return (
       <FormGroup check>
         <Label check>
           <Input
+            {...inputProps}
             type="checkbox"
             checked={value}
             onChange={e => onChange && onChange(e.target.checked)}
           />
-          {checkboxLabel && <span className="ml-1" ref="label">{checkboxLabel}</span>}
+          {checkboxLabel && (
+            <span className="ml-1" ref="label">
+              {checkboxLabel}
+            </span>
+          )}
         </Label>
       </FormGroup>
     );

--- a/test/components/CheckboxBooleanInput.spec.js
+++ b/test/components/CheckboxBooleanInput.spec.js
@@ -31,15 +31,23 @@ describe('<CheckboxBooleanInput />', () => {
   });
 
   it('should call onChange with checked state', () => {
-    component.simulate('change', { target: { checked: false }});
+    component.simulate('change', { target: { checked: false } });
     assert(onChange.calledWith(false));
   });
 
   it('should render checkboxLabel if specified', () => {
-    const wrapped = mount(
-      <CheckboxBooleanInput checkboxLabel="Yowza" />
-    );
+    const wrapped = mount(<CheckboxBooleanInput checkboxLabel="Yowza" />);
     assert.equal(wrapped.ref('label').text(), 'Yowza');
     assert.equal(wrapped.ref('label').exists(), true);
+  });
+
+  it('should allow you to pass through other props to the input', () => {
+    const checkbox = mount(
+      <CheckboxBooleanInput value onChange={onChange} disabled />
+    );
+
+    const input = checkbox.find(Input);
+
+    assert.equal(input.props().disabled, true);
   });
 });


### PR DESCRIPTION
`CheckboxListInput` does this too. Right now you can't disable checkboxes, and there are probably other props you might want to pass through too