### PR TITLE
BoundForm Props

### DIFF
--- a/src/components/BoundForm.js
+++ b/src/components/BoundForm.js
@@ -6,7 +6,6 @@ import Form from './Form';
 
 class BoundForm extends React.Component {
   static propTypes = {
-    children: PropTypes.node,
     errors: PropTypes.object,
     object: PropTypes.object.isRequired,
     onSubmit: PropTypes.func,
@@ -53,10 +52,10 @@ class BoundForm extends React.Component {
   }
 
   render() {
+    const { onSubmit, ...props } = this.props;
+
     return (
-      <Form onSubmit={this.onSubmit}>
-        {this.props.children}
-      </Form>
+      <Form onSubmit={this.onSubmit} {...props} />
     );
   }
 }

--- a/test/components/BoundForm.spec.js
+++ b/test/components/BoundForm.spec.js
@@ -22,7 +22,7 @@ describe('<BoundForm />', () => {
   const changeFunc = sinon.stub();
 
   const component = shallow(
-    <BoundForm object={data} errors={errors} onSubmit={submitFunc} onChange={changeFunc} />
+    <BoundForm object={data} errors={errors} onSubmit={submitFunc} onChange={changeFunc} other="stuff"/>
   );
 
   it('should provide a context', () => {
@@ -75,5 +75,9 @@ describe('<BoundForm />', () => {
     component.simulate('submit', { preventDefault });
     assert.equal(preventDefault.calledOnce, true);
     assert.equal(submitFunc.calledWith({ preventDefault }, component.state('formData')), true);
+  });
+
+  it('should forward other props to child form', () => {
+    assert.equal(component.prop('other'), 'stuff');
   });
 });


### PR DESCRIPTION
This PR forwards arbitrary properties to the underlying `Form` element in `BoundForm`.  Now, we can pass form level attributes (e.g. `noValidate`) and have it on the `Form`.