### PR TITLE
Fix deprecated mocha option

### DIFF
--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,3 +1,5 @@
---require jsdom-global/register babel-core/register ignore-styles
+--require jsdom-global/register
+--require babel-core/register
+--require ignore-styles
 --recursive
 --timeout 10000


### PR DESCRIPTION
`--compiler` is deprecated as per https://github.com/mochajs/mocha/wiki/compilers-deprecation