### PR TITLE
Update DateInput.js

### DIFF
--- a/src/components/DateInput.js
+++ b/src/components/DateInput.js
@@ -127,17 +127,17 @@ export default class DateInput extends React.Component {
       case 9: // TAB
         this.setState({ open: false });
         break;
-      case 27: // Esc
-        if (this.state.open) {
-          // To avoid parent elements handling the ESC key (like modals closing)
-          event.stopPropagation();
-          this.setState({ open: false });
-        }
-        break;
       case 13: // Enter
         if (this.state.open) {
           // To avoid submitting the form if DateInput is contained in a form
           event.preventDefault();
+          this.setState({ open: false });
+        }
+        break;
+      case 27: // Esc
+        if (this.state.open) {
+          // To avoid parent elements handling the ESC key (like modals closing)
+          event.stopPropagation();
           this.setState({ open: false });
         }
         break;


### PR DESCRIPTION
Follow up to #344, only make it happen when the date picker is open.

Also verified that TAB doesn't need to be handled as that is done by the Dropdown component.