### PR TITLE
gt - Default Modal fade to false

### DIFF
--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -3,6 +3,7 @@ import Modal from 'reactstrap/lib/Modal';
 Modal.defaultProps = {
   ...Modal.defaultProps,
   backdrop: false,
+  fade: false,
   zIndex: 10050
 };
 

--- a/stories/Modal.js
+++ b/stories/Modal.js
@@ -8,6 +8,7 @@ storiesOf('Modal', module)
     <Modal
       isOpen={boolean('isOpen', true)}
       backdrop={boolean('backdrop', true)}
+      fade={boolean('fade', false)}
       size={select('size', [null, 'sm', 'md', 'lg'], null)}
     >
       <ModalHeader toggle={() => {}}>Modal title</ModalHeader>


### PR DESCRIPTION
Disables fade in/out to match APM/MyCase default behavior, `fade` prop can still be added to enable