### PR TITLE
ds/ns - bump react-select-plus to get onInputChange fixes [#156112665]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2995,6 +2995,7 @@
       "version": "15.6.2",
       "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.2.tgz",
       "integrity": "sha1-zx7RXxKq1/FO9fLf4F5sQvke8Co=",
+      "dev": true,
       "requires": {
         "fbjs": "0.8.16",
         "loose-envify": "1.3.1",
@@ -10541,11 +10542,10 @@
       }
     },
     "react-input-autosize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/react-input-autosize/-/react-input-autosize-1.2.0.tgz",
-      "integrity": "sha1-hyQQcRWfdCEjiXaR2meW7DO1fQU=",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/react-input-autosize/-/react-input-autosize-2.2.1.tgz",
+      "integrity": "sha512-3+K4CD13iE4lQQ2WlF8PuV5htfmTRLH6MDnfndHM6LuBRszuXnuyIfE7nhSKt8AzRBZ50bu0sAhkNMeS5pxQQA==",
       "requires": {
-        "create-react-class": "15.6.2",
         "prop-types": "15.6.0"
       }
     },
@@ -10589,14 +10589,13 @@
       "dev": true
     },
     "react-select-plus": {
-      "version": "1.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/react-select-plus/-/react-select-plus-1.0.0-rc.5.tgz",
-      "integrity": "sha1-AJQgY9gkxX+c8fyYxH3yxjB9z/k=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/react-select-plus/-/react-select-plus-1.2.0.tgz",
+      "integrity": "sha512-IIvRMB7Od6YAdLVFef61Tdd6FWsi6Kc0qLlSRuR/GsgYwE7IeyRx88HJ95by4hJ8M7q2LWwIkXKMDSrAUrjwyw==",
       "requires": {
         "classnames": "2.2.5",
-        "create-react-class": "15.6.2",
         "prop-types": "15.6.0",
-        "react-input-autosize": "1.2.0"
+        "react-input-autosize": "2.2.1"
       }
     },
     "react-simple-di": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "lodash.noop": "^3.0.1",
     "prop-types": "^15.5.10",
     "react-fontawesome": "^1.4.0",
-    "react-select-plus": "1.0.0-rc.5",
+    "react-select-plus": "1.2.0",
     "react-text-mask": "~5.0.2",
     "react-transition-group": "~1.1.3",
     "reactstrap": "4.8.0",

--- a/src/components/Select.scss
+++ b/src/components/Select.scss
@@ -2,6 +2,7 @@
   // Import and override react-select's SCSS variables to match BS4:
   $select-input-height: 2.35rem !default;
   $select-input-internal-height: 2.25rem !default;
+  $select-arrow-width: 0.35rem !default;
 
   // Override react-select styles to match Saffron (TODO move to theme?)
   $select-input-bg-disabled: #eceeef;


### PR DESCRIPTION
onInputChange result was not used in the react-select
verison that we were depending on. It should now be
fixed in this version.

https://github.com/JedWatson/react-select/issues/1597

https://www.pivotaltracker.com/story/show/156112665

🤩