### PR TITLE
gt - Make Select input full width

### DIFF
--- a/src/components/Select.scss
+++ b/src/components/Select.scss
@@ -26,11 +26,12 @@
   // overlap any placeholder text.
   .Select-input {
     padding-left: 0.5rem;
+    width: 100%;
   }
-
   .Select-input > input {
     height: 100%;
     padding: 0;
+    width: 100% !important;
 
     &::-webkit-contacts-auto-fill-button {
       visibility: hidden;


### PR DESCRIPTION
Works around issue with default Bootstrap theme using 1rem as base font size, causing typed text to push left