### PR TITLE
rar - remove the yellow background color from an expanded row within …

### DIFF
--- a/src/components/SortableTable.js
+++ b/src/components/SortableTable.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Header from './SortableTable/Header.js';
 import Table from './Table.js';
+import style from './SortableTable.scss';
 
 class SortableTable extends React.Component {
   static propTypes = {
@@ -42,7 +43,7 @@ class SortableTable extends React.Component {
       </tr>,
       expanded && <tr hidden />,
       expanded && (
-        <tr>
+        <tr className="expandable-table__expansion">
           <td colSpan={columns.length}>
             {expanded}
           </td>

--- a/src/components/SortableTable.scss
+++ b/src/components/SortableTable.scss
@@ -1,0 +1,13 @@
+$table-even-background-color: #fff;
+$table-odd-background-color: #f6f6f6;
+
+:global {
+  tbody tr{
+    &.expandable-table__expansion:hover {
+      background-color: $table-even-background-color;
+      &:nth-of-type(odd) {
+        background-color: $table-odd-background-color;
+      }
+    }
+  }
+}


### PR DESCRIPTION
…a table

In saffron, an expanded row within a table does not have the yellow background color on hover as this is considered an anti-pattern. This change is intended to do the same in react-gears.

See https://qa.qa.appfolio.com/saffron/patterns/expandable_table
Expandable Row with More Information:
Anti-Pattern: Expandable row has a (yellow) row hover state

Used the same css class for an expandable row used in saffron: expandable-table__expansion