### PR TITLE
gt - Update SummaryBox to be BS4 friendly

### DIFF
--- a/src/components/SummaryBoxItem.js
+++ b/src/components/SummaryBoxItem.js
@@ -11,9 +11,9 @@ const SummaryBoxItem = ({ className, label, value, ...props }) => (
     className={classnames('rounded-0 shadow-0 bg-white border-secondary', className)}
     {...props}
   >
-    <CardBlock className="text-center">
-      <h3 className="mb-0 mt-1">{value}</h3>
+    <CardBlock className="text-center d-flex flex-column-reverse justify-content-end">
       <small className="text-muted text-uppercase">{label}</small>
+      <div className="h3 mb-0 mt-1">{value}</div>
     </CardBlock>
   </Card>
 );

--- a/test/components/SummaryBoxItem.spec.js
+++ b/test/components/SummaryBoxItem.spec.js
@@ -8,14 +8,14 @@ describe('<SummaryBoxItem />', () => {
   it('should render correctly', () => {
     const component = mount(<SummaryBoxItem label="Hello" value="World" />);
     assert(component);
-    assert(component.find('h3').text(), 'Hello');
+    assert(component.find('.h3').text(), 'Hello');
     assert(component.find('small').text(), 'World');
   });
 
   it('should show the default label and value if none specified', () => {
     const component = mount(<SummaryBoxItem />);
     assert(component);
-    assert(component.find('h3').text(), '--');
+    assert(component.find('.h3').text(), '--');
     assert(component.find('small').text(), '--');
   });
 


### PR DESCRIPTION
OPortal theme uses bootstrap 4 release, tweaks to look correct in BS4+ themes

Also improve accessibility