### PR TITLE
gt - Explicitly set Paginator classes to avoid APM conflict

### DIFF
--- a/src/components/Paginator.js
+++ b/src/components/Paginator.js
@@ -72,7 +72,7 @@ export default class Paginator extends React.Component {
       <div className="d-flex flex-column flex-sm-row-reverse justify-content-between align-items-center">
         <div>
           {(paginationState.totalPages > 1) && (
-            <Pagination size={size} className="m-0">
+            <Pagination size={size} className="m-0 p-0 border-0 flex-row">
               <FirstPageLink
                 page={1}
                 disabled={!paginationState.showPrevious()}


### PR DESCRIPTION
APM has a `.paginator` class that sets border, padding, flex.  Adds bootstrap util classes to set this only on React component