### PR TITLE
Change Time Input onChange arguments

### DIFF
--- a/src/components/TimeInput.js
+++ b/src/components/TimeInput.js
@@ -20,6 +20,8 @@ import Select from './Select';
 const format = fecha.format;
 const parse = fecha.parse;
 
+const INVALID_DATE = new Date(undefined);
+
 // TODO consider using <input type="time" /> when better browser support.
 
 // TODO use date-fns/parse to handle this behavior instead
@@ -121,7 +123,10 @@ export default class TimeInput extends React.Component {
 
   onChange = (selectedOption) => {
     this.setState({ selectedOption });
-    this.props.onChange(selectedOption ? selectedOption.value : '');
+
+    const value = selectedOption ? selectedOption.value : '';
+    const time = this.normalizeTime(parse(value, this.valueFormat) || INVALID_DATE);
+    this.props.onChange(value, time);
   }
 
   parseInput(input) {

--- a/test/components/TimeInput.spec.js
+++ b/test/components/TimeInput.spec.js
@@ -2,6 +2,7 @@ import React from 'react';
 import assert from 'assert';
 import { mount, shallow } from 'enzyme';
 import sinon from 'sinon';
+import isSameDay from 'date-fns/is_same_day';
 
 import { TimeInput, Select } from '../../src';
 
@@ -41,7 +42,11 @@ describe('<TimeInput />', () => {
 
     select.simulate('change', option);
     assert(callback.calledOnce);
-    sinon.assert.calledWith(callback, '12:00');
+    const [value, time] = callback.firstCall.args;
+    assert.equal(value, '12:00');
+    assert.equal(time.getHours(), 12);
+    assert.equal(time.getMinutes(), 0);
+    assert(isSameDay(time, new Date()));
   });
 
   it('should handle onChange when clearing the selection', () => {
@@ -52,7 +57,9 @@ describe('<TimeInput />', () => {
 
     select.simulate('change', option);
     assert(callback.calledOnce);
-    sinon.assert.calledWith(callback, '');
+    const [value, time] = callback.firstCall.args;
+    assert.equal(value, '');
+    assert(Number.isNaN(time.getTime()));
   });
 
   // TODO


### PR DESCRIPTION
This PR proposes two changes to the arguments passed to `onChange` in the `TimeInput`

1. On clearing the input, call `onChange` with `''` instead of `null`. This reflects the current behavior of the built in HTML `<input type="time" />` where onChange is called with the empty string. Previously this was called with `null` to mirror the behavior of `react-select` 

2. Call `onChange` with a second argument `time`. With the current `onChange` behavior, the callback is called with a string as the first argument, forcing the dev using this component to implement their own parsing if they want to use the time in any way other than the simplest use case of forwarding that string to the server. By passing a `Date` object to `onChange`, the consumer of this component can easily get the hours and minutes or coerce this value into a datetime. If someone thinks of a better API though please let me know 🙂 