### PR TITLE
Time Input Style Changes

### DIFF
--- a/src/components/TimeInput.js
+++ b/src/components/TimeInput.js
@@ -56,6 +56,7 @@ export default class TimeInput extends React.Component {
     allowOtherTimes: false,
     onChange: () => {},
     step: 30,
+    placeholder: 'Enter a time',
     timeFormat: 'h:mm A',
     noResultsText: 'Must be in the format HH:MM AM/PM'
   }

--- a/stories/TimeInput.js
+++ b/stories/TimeInput.js
@@ -15,7 +15,7 @@ storiesOf('TimeInput', module)
         max={text('max')}
         min={text('min')}
         onChange={action('onChange')}
-        placeholder={text('placeholder', 'Select a time')}
+        placeholder={text('placeholder', TimeInput.defaultProps.placeholder)}
         step={number('step', TimeInput.defaultProps.step)}
         timeFormat={text('timeFormat', TimeInput.defaultProps.timeFormat)}
       />


### PR DESCRIPTION
Two changes here:

1. Add a clock icon to the select component
2. Change default placeholder text to "Enter a time"

Before: 
<img width="965" alt="screen shot 2018-11-02 at 10 22 45 am" src="https://user-images.githubusercontent.com/11209547/47930472-4556c380-de89-11e8-8391-4de83f7ed316.png">

After:
<img width="968" alt="screen shot 2018-11-02 at 10 23 09 am" src="https://user-images.githubusercontent.com/11209547/47930486-556ea300-de89-11e8-9ace-31de7cb7c4b5.png">

