### PR TITLE
gt - Add `rowsWhenExpanded` prop to SortableTable & UncontrolledTable

### DIFF
--- a/src/components/SortableTable.js
+++ b/src/components/SortableTable.js
@@ -31,6 +31,7 @@ class SortableTable extends React.Component {
     rows: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
     rowClassName: PropTypes.func,
     rowExpanded: PropTypes.func,
+    rowsWhenExpanded: PropTypes.func,
     rowOnClick: PropTypes.func,
     truncate: PropTypes.bool
     // TODO? support sort type icons (FontAwesome has numeric, A->Z, Z->A)
@@ -41,11 +42,13 @@ class SortableTable extends React.Component {
     rows: [],
     rowClassName: () => undefined,
     rowExpanded: () => false,
+    rowsWhenExpanded: () => [],
     truncate: false
   };
 
-  renderRow(row, columns, rowClassName, rowExpanded, rowOnClick, truncate) {
+  renderRow(row, columns, rowClassName, rowExpanded, rowOnClick, rowsWhenExpanded, truncate) {
     const expanded = rowExpanded(row);
+    const rowsExpanded = rowsWhenExpanded(row);
     return [
       <tr
         key={row.key}
@@ -59,6 +62,24 @@ class SortableTable extends React.Component {
           </td>
         ))}
       </tr>,
+      rowsExpanded && (
+        rowsExpanded.map((extraRow, index) => [
+          <tr key={row.key ? `${row.key}-hidden-${index}` : null} hidden />,
+          <tr
+            key={`${row.key}-expanded-${index}`}
+            className="tr-expanded"
+          >
+            {columns.map(column => (
+              <td
+                key={column.key}
+                className={`border-top-0 ${generateColumnClassName(column, truncate)}`}
+              >
+                {column.cell(extraRow)}
+              </td>
+            ))}
+          </tr>
+        ])
+      ),
       expanded && <tr key={row.key ? `${row.key}-hidden` : null} hidden />,
       expanded && (
         <tr key={row.key ? `${row.key}-expanded` : null} className="tr-expanded">
@@ -71,7 +92,7 @@ class SortableTable extends React.Component {
   }
 
   render() {
-    const { columns, rowClassName, rowExpanded, rowOnClick, rows, style, truncate, ...props } = this.props;
+    const { columns, rowClassName, rowExpanded, rowOnClick, rows, rowsWhenExpanded, style, truncate, ...props } = this.props;
     const showColgroup = columns.some(column => column.width);
     const showFooter = columns.some(column => column.footer);
     const tableStyle = {
@@ -107,7 +128,7 @@ class SortableTable extends React.Component {
           </tr>
         </thead>
         <tbody>
-          {rows.map(row => this.renderRow(row, columns, rowClassName, rowExpanded, rowOnClick, truncate))}
+          {rows.map(row => this.renderRow(row, columns, rowClassName, rowExpanded, rowOnClick, rowsWhenExpanded, truncate))}
         </tbody>
         {showFooter &&
           <tfoot>

--- a/src/components/UncontrolledTable.js
+++ b/src/components/UncontrolledTable.js
@@ -142,7 +142,7 @@ export default class UncontrolledTable extends React.Component {
   render() {
     const { page } = this.state;
     const { ascending, column } = this.state.sort;
-    const { columns, expandable, pageSize, paginated, rowClassName, rowExpanded, rows, selectable, sort, onSelect, onExpand, ...props } = this.props;
+    const { columns, expandable, pageSize, paginated, rowClassName, rowExpanded, rows, rowsWhenExpanded, selectable, sort, onSelect, onExpand, ...props } = this.props;
     const cols = columns
       .filter(col => !col.hidden)
       .map(col => (col.sortable !== false) ?
@@ -166,7 +166,7 @@ export default class UncontrolledTable extends React.Component {
             onChange={this.toggleAll}
           />
         ),
-        cell: row => (
+        cell: row => row.uncontrolledExpandedRow ? null : (
           <input
             type="checkbox"
             className="mx-1"
@@ -182,7 +182,7 @@ export default class UncontrolledTable extends React.Component {
       cols.push({
         align: 'center',
         key: 'expand',
-        cell: row => (
+        cell: row => row.uncontrolledExpandedRow ? null : (
           <Button
             className="px-2 py-0"
             color="link"
@@ -208,6 +208,7 @@ export default class UncontrolledTable extends React.Component {
           rows={visibleRows}
           rowClassName={row => classnames({ 'table-info': this.selected(row) }, rowClassName(row))}
           rowExpanded={row => expandable && this.expanded(row) && rowExpanded(row)}
+          rowsWhenExpanded={row => expandable && this.expanded(row) && rowsWhenExpanded(row).map(r => ({ ...r, uncontrolledExpandedRow: true }))}
         />
         {paginated && [
           <hr />,

--- a/src/components/UncontrolledTable.js
+++ b/src/components/UncontrolledTable.js
@@ -208,7 +208,12 @@ export default class UncontrolledTable extends React.Component {
           rows={visibleRows}
           rowClassName={row => classnames({ 'table-info': this.selected(row) }, rowClassName(row))}
           rowExpanded={row => expandable && this.expanded(row) && rowExpanded(row)}
-          rowsWhenExpanded={row => expandable && this.expanded(row) && rowsWhenExpanded(row).map(r => ({ ...r, uncontrolledExpandedRow: true }))}
+          rowsWhenExpanded={row => expandable && this.expanded(row) && rowsWhenExpanded(row).map((r) => {
+            return {
+              ...r,
+              uncontrolledExpandedRow: true
+            };
+          })}
         />
         {paginated && [
           <hr />,

--- a/stories/Table.js
+++ b/stories/Table.js
@@ -3,7 +3,7 @@ import fecha from 'fecha';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { text, boolean, number, object, select } from '@storybook/addon-knobs';
-import { Table, SortableTable, UncontrolledTable } from '../src';
+import { Table, SortableTable, UncontrolledTable, ButtonGroup, Button } from '../src';
 
 const DATA = [
   { key: '111', expanded: false, first: 'Rufus Xavier Sarsparilla', last: 'Jones', email: 'rufus.xavier.sarsparilla@example.com', dob: new Date(1968, 6, 15) },
@@ -16,6 +16,12 @@ const DATA = [
   { key: '888', expanded: false, first: 'Tonya', last: 'Elliott', email: 'tonya.elliott@example.com', dob: new Date(1954, 7, 17) },
   { key: '999', expanded: false, first: 'Maxine', last: 'Turner', email: 'maxine.turner@example.com', dob: new Date(1961, 8, 19) },
   { key: '000', expanded: false, first: 'Max', last: 'Headroom', email: 'max.headroom@example.com', dob: new Date(1984, 6, 1) }
+];
+
+const EXPANDED_ROWS = [
+  { key: '121', expanded: false, first: 'Iggy', last: 'Pop', email: 'iggy.pop@example.com', dob: new Date(1956, 9, 7) },
+  { key: '232', expanded: false, first: 'Debbie', last: 'Harry', email: 'blondie.turner@example.com', dob: new Date(1955, 2, 29) },
+  { key: '343', expanded: false, first: 'Richard', last: 'Hell', email: 'rich.hell@example.com', dob: new Date(1957, 8, 14) }
 ];
 
 storiesOf('Table', module)
@@ -132,7 +138,15 @@ storiesOf('Table', module)
           }
         ]}
         rows={DATA}
-        rowExpanded={row => <div>{row.first} {row.last}</div>}
+        rowExpanded={row => (
+          <ButtonGroup size="sm">
+            <Button color="link" className="border-right">Alpha</Button>
+            <Button color="link" className="border-right">Bravo</Button>
+            <Button color="link" className="border-right">Charlie</Button>
+            <Button color="link" className="text-danger">Delta</Button>
+          </ButtonGroup>
+        )}
+        rowsWhenExpanded={() => EXPANDED_ROWS}
         sort={{ column: 'last', ascending: true }}
         expandable={boolean('expandable', false)}
         responsive={boolean('responsive', true)}


### PR DESCRIPTION
Allows for extra rows when expanded:

<img width="671" alt="screen shot 2018-12-05 at 9 17 05 am" src="https://user-images.githubusercontent.com/18536746/49531179-908c3980-f86e-11e8-94f0-73e8b5dce5e5.png">
