### PR TITLE
Support parsed value in onChange event for CurrencyInput

### DIFF
--- a/src/components/CurrencyInput.js
+++ b/src/components/CurrencyInput.js
@@ -37,6 +37,7 @@ const CurrencyInput = ({ size, ...props }) => {
     allowDecimal,
     allowNegative,
     includeThousandsSeparator,
+    onChange,
     ...inputProps
   } = props;
   /* eslint-enable  no-unused-vars */
@@ -57,10 +58,15 @@ const CurrencyInput = ({ size, ...props }) => {
     pipe: preventMultipleDecimalPoint,
   };
 
+  function handleOnChange(e) {
+    const amount = parseFloat(e.target.value.replace(/,/g, '')); // TODO support I18n
+    onChange(e, amount);
+  }
+
   return (
     <InputGroup size={size} className={props.className}>
       <InputGroupAddon addonType="prepend">$</InputGroupAddon>
-      <MaskedInput {...maskedProps} />
+      <MaskedInput {...maskedProps} onChange={handleOnChange} />
     </InputGroup>
   );
 };
@@ -69,6 +75,7 @@ CurrencyInput.defaultProps = {
   allowDecimal: true,
   allowNegative: false,
   includeThousandsSeparator: true,
+  onChange: () => {}
 };
 
 CurrencyInput.propTypes = {
@@ -76,6 +83,7 @@ CurrencyInput.propTypes = {
   allowNegative: PropTypes.bool,
   className: PropTypes.string,
   includeThousandsSeparator: PropTypes.bool,
+  onChange: PropTypes.func,
   size: PropTypes.string,
   state: PropTypes.any,
   type: PropTypes.any

--- a/stories/CurrencyInput.js
+++ b/stories/CurrencyInput.js
@@ -1,18 +1,18 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
+import { action, storiesOf } from '@storybook/react';
 
 import { CurrencyInput } from '../src';
 
 storiesOf('CurrencyInput', module)
   .addWithInfo('default props', () => (
-    <CurrencyInput />
+    <CurrencyInput onChange={action('onChange')} />
   ))
   .addWithInfo('allow negative', () => (
-    <CurrencyInput allowNegative />
+    <CurrencyInput allowNegative onChange={action('onChange')} />
   ))
   .addWithInfo('disallow decimal', () => (
-    <CurrencyInput allowDecimal={false} />
+    <CurrencyInput allowDecimal={false} onChange={action('onChange')} />
   ))
   .addWithInfo('disallow comma', () => (
-    <CurrencyInput includeThousandsSeparator={false} />
+    <CurrencyInput includeThousandsSeparator={false} onChange={action('onChange')} />
   ));

--- a/test/components/CurrencyInput.spec.js
+++ b/test/components/CurrencyInput.spec.js
@@ -34,6 +34,18 @@ describe('<CurrencyInput />', () => {
       const input = component.find('input');
       assert.equal(input.getDOMNode().value, '123456');
     });
+
+    it('should call onChange', () => {
+      const spy = sinon.spy();
+      const component = mount(<CurrencyInput onChange={spy} />);
+      const input = component.find('input');
+
+      input.simulate('input', { target: { value: '123,456,789.99' } });
+
+      assert(spy.calledOnce);
+      assert.strictEqual(spy.firstCall.args[0].target.value, '123,456,789.99');
+      assert.strictEqual(spy.firstCall.args[1], 123456789.99);
+    });
   });
 
   context('negative numbers', () => {
@@ -47,6 +59,18 @@ describe('<CurrencyInput />', () => {
       const component = mount(<CurrencyInput value="-123" allowNegative />);
       const input = component.find('input');
       assert.equal(input.getDOMNode().value, '-123');
+    });
+
+    it('should call onChange', () => {
+      const spy = sinon.spy();
+      const component = mount(<CurrencyInput onChange={spy} />);
+      const input = component.find('input');
+
+      input.simulate('input', { target: { value: '-123,456,789.99' } });
+
+      assert(spy.calledOnce);
+      assert.strictEqual(spy.firstCall.args[0].target.value, '-123,456,789.99');
+      assert.strictEqual(spy.firstCall.args[1], -123456789.99);
     });
   });
 
@@ -87,6 +111,18 @@ describe('<CurrencyInput />', () => {
       assert.equal(input.getDOMNode().value, '0.');
     });
 
+    it('should call onChange', () => {
+      const spy = sinon.spy();
+      const component = mount(<CurrencyInput onChange={spy} />);
+      const input = component.find('input');
+
+      input.simulate('input', { target: { value: '123,456,789.' } });
+
+      assert(spy.calledOnce);
+      assert.strictEqual(spy.firstCall.args[0].target.value, '123,456,789.');
+      assert.strictEqual(spy.firstCall.args[1], 123456789);
+    });
+
     // TODO skipped pending this issue/question: https://github.com/text-mask/text-mask/issues/372
     it.skip('should zero pad 1 decimal', () => {
       const component = mount(<CurrencyInput onChange={callback} value={1234.5} />);
@@ -107,5 +143,17 @@ describe('<CurrencyInput />', () => {
     const component = mount(<CurrencyInput onChange={callback} value="Veni, Vedi, Vici" />);
     const input = component.find('input');
     assert.equal(input.getDOMNode().value, '');
+  });
+
+  it('should call onChange with NaN for invalid numbers', () => {
+    const spy = sinon.spy();
+    const component = mount(<CurrencyInput onChange={spy} />);
+    const input = component.find('input');
+
+    input.simulate('input', { target: { value: '' } });
+
+    assert(spy.calledOnce);
+    assert.strictEqual(spy.firstCall.args[0].target.value, '');
+    assert(Number.isNaN(spy.firstCall.args[1]));
   });
 });


### PR DESCRIPTION
The goal of this PR is to make `CurrencyInput`'s `onChange` event easier to work with by providing a second argument to `onChange` with a parsed float value.

Before:
```
function handleOnChange(e) => {
  // e.target.value is a string and it could have different characters in it. e.g. '123,456.78'
}
<CurrencyInput onChange={handleOnChange} />
```

After:
```
function handleOnChange(e, parsedFloat) => {
  // e.target.value is a string and parsedFloat is either a float or NaN
}
<CurrencyInput onChange={handleOnChange} />
```

This change should be backward compatible. Let me know if it's not or missing anything.

Link to the original conversation on Slack: https://appfolio.slack.com/archives/C38S5MY91/p1544121132000200