### PR TITLE
Eliminate invalid nesting of links within a disabled SelectOption

### DIFF
--- a/src/components/SelectOption.js
+++ b/src/components/SelectOption.js
@@ -30,13 +30,14 @@ export default class SelectOption extends React.Component {
   blockEvent = (event) => {
     event.preventDefault();
     event.stopPropagation();
-    if ((event.target.tagName !== 'A') || !('href' in event.target)) {
+    const anchor = event.target.closest('.Select-option a');
+    if (!anchor || !('href' in anchor)) {
       return;
     }
-    if (event.target.target) {
-      window.open(event.target.href, event.target.target);
+    if (anchor.target) {
+      window.open(anchor.href, anchor.target);
     } else {
-      window.location.href = event.target.href;
+      window.location.href = anchor.href;
     }
   }
 
@@ -70,6 +71,7 @@ export default class SelectOption extends React.Component {
 
     return option.disabled ? (
       <DropdownItem
+        tag="div" // Eliminates invalid nesting of anchors within a button (default tag)
         className={className}
         onMouseDown={this.blockEvent}
         onClick={this.blockEvent}


### PR DESCRIPTION
Team Pickle from MyCase noticed that links/anchors within a disabled SelectOption are not functioning properly in Firefox, yet work as expected in Chrome and Safari.  This issue was due to the invalid nesting of an `<a>` tag within a `<button>` provided by the `DropdownItem` reactstrap component.  

The proposed solution here is to change the underlying `DropdownItem` tag only for disabled select options to `<div>`.  In addition, the `blockEvent()` method was updated to detect that a link was clicked even if the `event.target` was one of the anchor's child elements. 

Effectively, you can have a select option like the following:
```js
const options = [
  {
    label: (
      <>
        Pro Customer Support <a href="/url" target="_blank">Upgrade now!</a>
      </>
    ),
    value: '',
    disabled: true
  }
];
```