### PR TITLE
Use separate handlers for disabled select option onMouseDown and onClick

### DIFF
--- a/src/components/SelectOption.js
+++ b/src/components/SelectOption.js
@@ -30,6 +30,11 @@ export default class SelectOption extends React.Component {
   blockEvent = (event) => {
     event.preventDefault();
     event.stopPropagation();
+  }
+
+  handleDisabledOptionClick = (event) => {
+    event.preventDefault();
+    event.stopPropagation();
     const anchor = event.target.closest('.Select-option a');
     if (!anchor || !('href' in anchor)) {
       return;
@@ -74,7 +79,7 @@ export default class SelectOption extends React.Component {
         tag="div" // Eliminates invalid nesting of anchors within a button (default tag)
         className={className}
         onMouseDown={this.blockEvent}
-        onClick={this.blockEvent}
+        onClick={this.handleDisabledOptionClick}
       >
         {this.props.children}
       </DropdownItem>


### PR DESCRIPTION
Related: https://github.com/appfolio/react-gears/pull/524

### This PR solves the following issue:
Only in Microsoft Edge, clicking the a link in a disabled select option opens the href twice instead of once. 

The cause is disabled SelectOptions hook the same event handler for both `onMouseDown` and `onClick` events. A single click would trigger both of these events, thus calling the event handler twice and opening 2 windows/tabs instead of 1.

The fix is to only check for and follow links in one of the event handlers (`onClick`), not both.