### PR TITLE
gt - Add reverse prop to SummaryBox

### DIFF
--- a/src/components/SummaryBox.js
+++ b/src/components/SummaryBox.js
@@ -3,17 +3,22 @@ import React from 'react';
 import CardGroup from './CardGroup';
 import SummaryBoxItem from './SummaryBoxItem';
 
-const SummaryBox = ({ children, items, ...props }) => (
+const SummaryBox = ({ children, items, reverse, ...props }) => (
   <CardGroup {...props}>
     {items ?
-      items.map((item, i) => <SummaryBoxItem key={item.key || i} value={item.value} label={item.label} />) :
+      items.map((item, i) => <SummaryBoxItem key={item.key || i} value={item.value} label={item.label} reverse={reverse} />) :
       children}
   </CardGroup>
 );
 
 SummaryBox.propTypes = {
   children: PropTypes.node,
-  items: PropTypes.array
+  items: PropTypes.array,
+  reverse: PropTypes.bool
+};
+
+SummaryBox.defaultProps = {
+  reverse: true
 };
 
 export default SummaryBox;

--- a/src/components/SummaryBoxItem.js
+++ b/src/components/SummaryBoxItem.js
@@ -4,28 +4,41 @@ import classnames from 'classnames';
 import Card from './Card';
 import CardBody from './CardBody';
 
-const SummaryBoxItem = ({ className, label, value, ...props }) => (
-  <Card
-    color="secondary"
-    outline
-    className={classnames('rounded-0 shadow-0 bg-white border-secondary', className)}
-    {...props}
-  >
-    <CardBody className="text-center d-flex flex-column-reverse justify-content-end">
-      <small className="text-muted text-uppercase">{label}</small>
-      <div className="h3 mb-0 mt-1">{value}</div>
-    </CardBody>
-  </Card>
-);
+const SummaryBoxItem = ({ className, label, reverse, value, ...props }) => {
+  const bodyClassNames = classnames('text-center d-flex justify-content-end', {
+    'flex-column-reverse': reverse,
+    'flex-column': !reverse
+  });
+  const valueClassNames = classnames('h3', {
+    'mb-1 mt-0': reverse,
+    'mb-0 mt-1': !reverse
+  });
+
+  return (
+    <Card
+      color="secondary"
+      outline
+      className={classnames('rounded-0 shadow-0 bg-white border-secondary', className)}
+      {...props}
+    >
+      <CardBody className={bodyClassNames}>
+        <small className="text-muted text-uppercase">{label}</small>
+        <div className={valueClassNames}>{value}</div>
+      </CardBody>
+    </Card>
+  );
+};
 
 SummaryBoxItem.propTypes = {
   className: PropTypes.string,
   label: PropTypes.node,
+  reverse: PropTypes.bool,
   value: PropTypes.node
 };
 
 SummaryBoxItem.defaultProps = {
   label: '--',
+  reverse: true,
   value: '--'
 };
 

--- a/stories/SummaryBox.js
+++ b/stories/SummaryBox.js
@@ -3,7 +3,7 @@ import { storiesOf } from '@storybook/react';
 
 import SummaryBox from '../src/components/SummaryBox';
 import SummaryBoxItem from '../src/components/SummaryBoxItem';
-import { text } from '@storybook/addon-knobs';
+import { boolean, text } from '@storybook/addon-knobs';
 
 const link = <a href="#">Link</a>;
 
@@ -16,10 +16,10 @@ const items = [
 
 storiesOf('SummaryBox', module)
   .addWithInfo('with items', () => (
-    <SummaryBox items={items} />
+    <SummaryBox items={items} reverse={boolean('reverse', SummaryBox.defaultProps.reverse)} />
   ))
   .addWithInfo('with children', () => (
-    <SummaryBox>
+    <SummaryBox reverse={boolean('reverse', SummaryBox.defaultProps.reverse)}>
       <SummaryBoxItem value={link} label="Bravo" />
       <SummaryBoxItem value="Charlie" />
       <SummaryBoxItem label="Foxtrot" />
@@ -31,5 +31,6 @@ storiesOf('SummaryBox', module)
     <SummaryBoxItem
       value={text('value', 'Live from New York')}
       label={text('label', 'It\'s Saturday Night')}
+      reverse={boolean('reverse', SummaryBoxItem.defaultProps.reverse)}
     />
   ));

--- a/test/components/SummaryBox.spec.js
+++ b/test/components/SummaryBox.spec.js
@@ -4,6 +4,12 @@ import { shallow } from 'enzyme';
 
 import { SummaryBox, SummaryBoxItem } from '../../src';
 
+const items = [
+  { value: 'Alpha', label: 'Team' },
+  { value: 'Bravo', label: 'Johnny' },
+  { value: 'Charlie', label: 'Brown' }
+];
+
 describe('<SummaryBox />', () => {
   it('should render correctly', () => {
     const component = shallow(<SummaryBox />);
@@ -17,11 +23,6 @@ describe('<SummaryBox />', () => {
   });
 
   it('should render items as SummaryBoxItems', () => {
-    const items = [
-      { value: 'Alpha', label: 'Team' },
-      { value: 'Bravo', label: 'Johnny' },
-      { value: 'Charlie', label: 'Brown' }
-    ];
     const component = shallow(
       <SummaryBox items={items}>
         <span>Hi</span>
@@ -35,6 +36,18 @@ describe('<SummaryBox />', () => {
       assert.equal(child.prop('value'), items[i].value);
       assert.equal(child.prop('label'), items[i].label);
     });
+  });
+
+  it('should reverse all items when specified', () => {
+    const component = shallow(<SummaryBox items={items} reverse />);
+    const children = component.find(SummaryBoxItem);
+    children.forEach(child => assert.equal(child.prop('reverse'), true));
+  });
+
+  it('should not reverse all items when specified', () => {
+    const component = shallow(<SummaryBox items={items} reverse={false} />);
+    const children = component.find(SummaryBoxItem);
+    children.forEach(child => assert.equal(child.prop('reverse'), false));
   });
 
   it('should render children', () => {

--- a/test/components/SummaryBoxItem.spec.js
+++ b/test/components/SummaryBoxItem.spec.js
@@ -19,6 +19,16 @@ describe('<SummaryBoxItem />', () => {
     assert(component.find('small').text(), '--');
   });
 
+  it('should reverse when specified', () => {
+    const component = mount(<SummaryBoxItem id="mertz" reverse />);
+    assert(component.find('.flex-column-reverse').exists());
+  });
+
+  it('should reverse when specified', () => {
+    const component = mount(<SummaryBoxItem id="mertz" reverse={false} />);
+    assert(component.find('.flex-column').exists());
+  });
+
   it('should allow arbitrary props', () => {
     const component = mount(<SummaryBoxItem id="mertz" />);
     assert(component.find('#mertz').exists());


### PR DESCRIPTION
- Add reverse prop to SummaryBox and SummaryBoxItem.
- Update tests and stories.

<img width="404" alt="Screen Shot 2019-05-15 at 11 15 40 AM" src="https://user-images.githubusercontent.com/18536746/57798940-ce856780-7702-11e9-9eaa-372ddcfcb071.png">