### PR TITLE
Prevent onSort prop from being passed to SortableTable

### DIFF
--- a/src/components/UncontrolledTable.js
+++ b/src/components/UncontrolledTable.js
@@ -139,7 +139,7 @@ export default class UncontrolledTable extends React.Component {
   render() {
     const { page } = this.state;
     const { ascending, column } = this.state.sort;
-    const { columns, expandable, pageSize, paginated, rowExpanded, rows, selectable, sort, onSelect, onExpand, ...props } = this.props;
+    const { columns, expandable, pageSize, paginated, rowExpanded, rows, selectable, sort, onSelect, onExpand, onSort, ...props } = this.props;
     const cols = columns
       .filter(col => !col.hidden)
       .map(col => (col.sortable !== false) ?


### PR DESCRIPTION
This prevents a warning message saying `Warning: Unknown event handler property 'onSort'. It will be ignored`