### PR TITLE
Bump reactstrap to 6.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13490,9 +13490,9 @@
       }
     },
     "reactstrap": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/reactstrap/-/reactstrap-6.3.1.tgz",
-      "integrity": "sha512-maPXx5DREMfN1Gudx3R3zMoWgjQX+rGSbmEMOux3cr0lLUx5jDR9c3a1HDRgFcDyNKiGMa+MmLPJeFXUl7lihw==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/reactstrap/-/reactstrap-6.5.0.tgz",
+      "integrity": "sha512-dWb3fB/wBAiQloteKlf+j9Nl2VLe6BMZgTEt6hpeTt0t9TwtkeU+2v2NBYONZaF4FZATfMiIKozhWpc2HmLW1g==",
       "requires": {
         "classnames": "2.2.5",
         "lodash.isfunction": "3.0.9",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "react-sortable-hoc": "^1.4.0",
     "react-text-mask": "~5.0.2",
     "react-transition-group": "^2.3.1",
-    "reactstrap": "~6.3.1",
+    "reactstrap": "^6.5.0",
     "text-mask-addons": "^3.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Features from 6.4 & 6.5:

https://github.com/reactstrap/reactstrap/releases/tag/6.4.0
https://github.com/reactstrap/reactstrap/releases/tag/6.5.0