### PR TITLE
Correct Select scrolling

### DIFF
--- a/src/components/SelectOption.js
+++ b/src/components/SelectOption.js
@@ -68,7 +68,7 @@ export default class SelectOption extends React.Component {
 
   render() {
     const { option, instancePrefix, optionIndex, isDisabled, isFocused, isSelected } = this.props;
-    const className = classNames(this.props.className, option.className, {
+    const className = classNames(this.props.className, option.className, 'text-truncate', {
       'text-muted': isDisabled,
       'bg-light': isSelected && !isFocused,
       'bg-primary text-white': isFocused


### PR DESCRIPTION
Adds `text-truncate` to Select options to avoid weird scrolling on Chrome.

<img width="205" alt="Screen Shot 2019-07-17 at 7 55 22 AM" src="https://user-images.githubusercontent.com/18536746/61385986-46d5e980-a868-11e9-8944-6a766cc11a7b.png">
