### PR TITLE
Remove placement property override in popover component

### DIFF
--- a/src/components/Popover.js
+++ b/src/components/Popover.js
@@ -1,10 +1,4 @@
-import PropTypes from 'prop-types';
 import Popover from 'reactstrap/lib/Popover';
-
-Popover.propTypes = {
-  ...Popover.propTypes,
-  placement: PropTypes.oneOf(['top', 'bottom', 'left', 'right']) // Overrides reactstrap's unsupported options.
-};
 
 Popover.defaultProps = {
   ...Popover.defaultProps,


### PR DESCRIPTION
... so we can use all the available placement options in `Popover` from `reactstrap`