### PR TITLE
fix date input dropdown placement

### DIFF
--- a/src/components/DateInput.js
+++ b/src/components/DateInput.js
@@ -62,6 +62,7 @@ export default class DateInput extends React.Component {
       PropTypes.string,
       PropTypes.object
     ]),
+    direction: PropTypes.string,
     disabled: PropTypes.bool,
     footer: PropTypes.node,
     header: PropTypes.node,
@@ -257,7 +258,7 @@ export default class DateInput extends React.Component {
     // TODO extract a DropdownInput component that can encapsulate the defaultValue/value controlled/uncontrolled behavior.
     return (
       <div>
-        <Dropdown isOpen={!disabled && open} toggle={this.toggle}>
+        <Dropdown direction={this.props.direction} isOpen={!disabled && open} toggle={this.toggle}>
           <DropdownToggle tag="div" disabled>
             <InputGroup className={className}>
               <input

--- a/stories/DateInput.js
+++ b/stories/DateInput.js
@@ -10,6 +10,7 @@ storiesOf('DateInput', module)
       <DateInput
         dateFormat={text('dateFormat', DateInput.defaultProps.dateFormat)}
         showOnFocus={boolean('showOnFocus', DateInput.defaultProps.showOnFocus)}
+        direction={text('direction', 'down')}
         disabled={boolean('disabled', DateInput.defaultProps.disabled)}
         readOnly={boolean('readOnly', false)}
         onBlur={action('onBlur')}


### PR DESCRIPTION
If the date input was at the bottom of the window, the calendar would dropdown out of view and fail to automatically drop up instead.

Before:
![image](https://user-images.githubusercontent.com/2031802/64741777-9c1c2900-d4ae-11e9-9fe5-10af4573a542.png)

After:
![image](https://user-images.githubusercontent.com/2031802/64739802-0087ba00-d4a8-11e9-8808-08b79838d0ab.png)

