### PR TITLE
Allow global props passed to template component

### DIFF
--- a/src/components/HasManyFields.js
+++ b/src/components/HasManyFields.js
@@ -49,6 +49,7 @@ class HasManyFields extends React.Component {
     onChange: PropTypes.func,
     template: PropTypes.oneOfType([PropTypes.func, PropTypes.element])
       .isRequired,
+    templateProps: PropTypes.object,
     value: PropTypes.array,
     minimumRows: PropTypes.number,
     maximumRows: PropTypes.number,
@@ -65,6 +66,7 @@ class HasManyFields extends React.Component {
     minimumRows: 1,
     maximumRows: Infinity,
     reorderable: false,
+    templateProps: {}
   };
 
   constructor(props) {
@@ -162,7 +164,7 @@ class HasManyFields extends React.Component {
   };
 
   renderHasManyFieldsRow = (key, index, value) => {
-    const { template: Template, disabled, errors, minimumRows } = this.props;
+    const { template: Template, disabled, errors, minimumRows, templateProps } = this.props;
     const refProps = this.isStateless(Template) ? {} : { ref: this.setRowReference(index) };
 
     return (
@@ -178,6 +180,7 @@ class HasManyFields extends React.Component {
           onChange={this.updateItem(index)}
           disabled={disabled}
           {...refProps}
+          {...templateProps}
         />
       </HasManyFieldsRow>
     );

--- a/test/components/HasManyFields.spec.js
+++ b/test/components/HasManyFields.spec.js
@@ -110,6 +110,16 @@ describe('<HasManyFields />', () => {
         assert.equal(component.instance().rowRefs.length, 0);
       });
     });
+
+    context('template props', () => {
+      it('should pass the template props to the template', () => {
+        props.templateProps = { foo: 'Gary' };
+        component = mount(<HasManyFields {...props} />);
+        component.find(Input).forEach((input) => {
+          assert.equal(input.prop('foo'), 'Gary');
+        });
+      });
+    });
   });
 
   describe('controlled', () => {


### PR DESCRIPTION
We have had a few cases where it would be useful to pass global props down to the template components. Currently in order to do this you have to do some really awkward workaround.