### PR TITLE
Change Popover trigger

### DIFF
--- a/src/components/Popover.js
+++ b/src/components/Popover.js
@@ -3,6 +3,7 @@ import Popover from 'reactstrap/lib/Popover';
 Popover.defaultProps = {
   ...Popover.defaultProps,
   fade: false,
+  trigger: 'legacy'
 };
 
 export default Popover;


### PR DESCRIPTION
This changes popover trigger to previous behavior, where click outside will close the Popover.  Also corrects HelpBubble.