### PR TITLE
Add type declaration for Modal component

### DIFF
--- a/src/components/Modal.d.ts
+++ b/src/components/Modal.d.ts
@@ -1,0 +1,2 @@
+import Modal from 'reactstrap/lib/Modal';
+export default Modal;


### PR DESCRIPTION
We are seeing linting errors when trying to use the `Modal` component from `react-gears`. Example failure: https://circleci.com/gh/appfolio/mycase-react/68?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

I think this is caused by not having a declaration for the `Modal` component's interface. Hence, viola 🎉