### PR TITLE
don't propagate checkbox events on sortable table

### DIFF
--- a/src/components/SortableTable.js
+++ b/src/components/SortableTable.js
@@ -113,7 +113,10 @@ class SortableTable extends React.Component {
               className="mx-1"
               id={selectAllId}
               checked={allSelected}
-              onChange={e => onSelectAll(e.target.checked)}
+              onChange={(e) => {
+                e.stopPropagation();
+                onSelectAll(e.target.checked);
+              }}
             />
           </>
         ),
@@ -127,7 +130,10 @@ class SortableTable extends React.Component {
                 type="checkbox"
                 className="mx-1"
                 checked={rowSelected(row)}
-                onChange={e => onSelect(row, e.target.checked)}
+                onChange={(e) => {
+                  e.stopPropagation();
+                  onSelect(row, e.target.checked);
+                }}
               />
             </>);
         },


### PR DESCRIPTION
QPC discovered a bug where selecting a row in sortable table triggers the `rowOnClick` handler, preventing seamless selection of multiple rows. This change stops event propagation when handling row selections such that they don't trigger `rowOnClick`.