### PR TITLE
sortable table - move `stopPropagation` to `onClick` handler

### DIFF
--- a/src/components/SortableTable.js
+++ b/src/components/SortableTable.js
@@ -113,10 +113,8 @@ class SortableTable extends React.Component {
               className="mx-1"
               id={selectAllId}
               checked={allSelected}
-              onChange={(e) => {
-                e.stopPropagation();
-                onSelectAll(e.target.checked);
-              }}
+              onClick={e => e.stopPropagation()}
+              onChange={e => onSelectAll(e.target.checked)}
             />
           </>
         ),
@@ -130,10 +128,8 @@ class SortableTable extends React.Component {
                 type="checkbox"
                 className="mx-1"
                 checked={rowSelected(row)}
-                onChange={(e) => {
-                  e.stopPropagation();
-                  onSelect(row, e.target.checked);
-                }}
+                onClick={e => e.stopPropagation()}
+                onChange={e => onSelect(row, e.target.checked)}
               />
             </>);
         },

--- a/test/components/SortableTable.spec.js
+++ b/test/components/SortableTable.spec.js
@@ -403,5 +403,33 @@ describe('<SortableTable />', () => {
       wrapper.find('th input').first().simulate('change', { target: { checked: false } });
       assert(onSelectAll.calledWith(false));
     });
+
+    it('should not call rowOnClick when row checkbox is clicked', () => {
+      const targetRow = 'cool row';
+      const rows = [targetRow];
+      const onClick = sinon.spy();
+      const onSelect = sinon.spy();
+
+      const wrapper = mount(
+        <SortableTable
+          columns={columns}
+          rows={rows}
+          rowOnClick={onClick}
+          onSelect={onSelect}
+          onSelectAll={sinon.stub()}
+          rowExpanded={sinon.stub()}
+          rowSelected={sinon.stub()}
+        />
+      );
+
+      const clickEvent = { target: { checked: true } };
+      const changeEvent = { target: { checked: true } };
+      const checkbox = wrapper.find('tbody tr input').first();
+      checkbox.simulate('click', clickEvent);
+      checkbox.simulate('change', changeEvent);
+
+      assert(onSelect.calledWith(targetRow, clickEvent.target.checked));
+      assert(onClick.notCalled);
+    });
   });
 });


### PR DESCRIPTION
`stopPropagation` needs to be handled in `onClick` instead of `onChange`. Made a mistake in https://github.com/appfolio/react-gears/pull/643 😅 