### PR TITLE
ScrollContainer shadow z-index must be lower than Dropdown z-index

### DIFF
--- a/src/components/ScrollContainer.scss
+++ b/src/components/ScrollContainer.scss
@@ -8,7 +8,7 @@
   right: 0px;
   pointer-events: none;
   position: absolute;
-  z-index: 20000; // TODO test
+  z-index: 990; // must be lower than Dropdown
 }
 
 $r: 8px;


### PR DESCRIPTION
<img width="558" alt="Screen Shot 2020-02-10 at 5 07 58 PM" src="https://user-images.githubusercontent.com/1709056/74264896-57dbc180-4cb6-11ea-98aa-dcba8de3b729.png">

This is a conflict of z-indexes:
ScrollContainer is 20000
https://github.com/appfolio/react-gears/blob/af912f49058f4c2fd8c8895698b3865cffd5faa5/src/components/ScrollContainer.scss#L11

Dropdown is 1000
https://github.com/twbs/bootstrap/blob/1238734922f915da825e4fd61c7ee0e9d4a6473f/scss/_variables.scss#L809

This manifests in production when there is a `Checklist` component that is above a `DateInput`.  It is the `Checklist`'s `ScrollContainer` that conflicts with the `DatInput`'s `Dropdown`.