### PR TITLE
Remove check attribute from div on FormChoice

### DIFF
--- a/src/components/FormChoice.js
+++ b/src/components/FormChoice.js
@@ -61,6 +61,7 @@ class FormChoice extends React.Component {
         />
         <Label
           className="form-check-label"
+          check={!inline}
           for={this.id}
           style={{ cursor: disabled && 'not-allowed' }}
         >


### PR DESCRIPTION
MyCase started using FormChoice and got this error. 
![image (5)](https://user-images.githubusercontent.com/13619440/77976314-7e2ede00-72b1-11ea-8e27-c5854228afac.png)
