### PR TITLE
Handle unhandled promise rejections

### DIFF
--- a/test/helpers.js
+++ b/test/helpers.js
@@ -11,3 +11,19 @@ global.requestAnimationFrame = (cb) => {
 };
 
 global.cancelAnimationFrame = () => {};
+
+// Throw exceptions on unhandled promise rejections to prevent tests
+// from silently failing async. In the future mocha might handle this
+// automatically for us
+//
+let unhandledRejection = false;
+process.on('unhandledRejection', (reason, promise) => {
+  console.error('unhandled rejection:', reason || promise); // eslint-disable-line no-console
+  unhandledRejection = true;
+  throw promise;
+});
+process.prependListener('exit', (code) => {
+  if (unhandledRejection && code === 0) {
+    process.exit(1);
+  }
+});


### PR DESCRIPTION
Our accessibility tests need to be run asynchronously because of `axe-core`:
https://github.com/appfolio/react-gears/blob/740ec87fd5ec923f3b134672723eae67c18986b8/test/a11yHelpers.js

Unfortunately, if our code fails an assertion or throws an error inside of a promise, mocha will only print the error to the screen but the tests won't actually fail. This is a long-standing issue with mocha. 

https://github.com/mochajs/mocha/issues/2640

In the future mocha might handle this automatically for us, but for now we need this workaround for async tests. 

This was copied from property app (thanks @mathewbaltes !)
https://github.com/appfolio/apm_bundle/blob/b803535c547c0759176503b8190aa12b972afe9e/apps/property/helpers.js#L49-L63