### PR TITLE
Update version to correct node version error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18705,9 +18705,9 @@
       "dev": true
     },
     "use-local-storage-state": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/use-local-storage-state/-/use-local-storage-state-3.0.1.tgz",
-      "integrity": "sha512-8o7sF8vDyVf4txn7l2JCxkKLaE1GX4DRmsFTFxP7Xhv0Hy0vAN2XKQ7icHo+fq+R4ZsQvVMrL9/6QB1yzE0V7g=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/use-local-storage-state/-/use-local-storage-state-4.0.0.tgz",
+      "integrity": "sha512-zK0pldkQecRooIhgepEbQToKHBCOMgV0Uj+7E775yifJIek02O49p/URrSzbw+gRuTO+oeDZIwxCbzhtbwJItA=="
     },
     "util": {
       "version": "0.11.1",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "reactstrap": "^8.1.1",
     "text-mask-addons": "^3.8.0",
     "uniqid": "^5.0.3",
-    "use-local-storage-state": "^3.0.1",
+    "use-local-storage-state": "^4.0.0",
     "uuid": "^8.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
New version corrects issue with using bleeding-edge syntax:
`} catch {`