### PR TITLE
Make TooltipButton tabbable when disabled

### DIFF
--- a/src/components/TooltipButton.tsx
+++ b/src/components/TooltipButton.tsx
@@ -32,7 +32,7 @@ const TooltipButton: FunctionComponent<TooltipButtonProps> = ({
           {tooltip}
         </Tooltip>
       )}
-      <div id={id} className={className}>
+      <div tabIndex={disabled && tooltip ? 0 : -1} id={id} className={className}>
         <Button
           disabled={disabled}
           style={{ pointerEvents: disabled ? 'none' : 'auto' }}

--- a/test/components/TooltipButton.spec.js
+++ b/test/components/TooltipButton.spec.js
@@ -27,6 +27,11 @@ describe('<TooltipButton />', () => {
       assert.equal(ButtonComponent.prop('disabled'), false);
     });
 
+    it('should not have a tabbable wrapper div by default', () => {
+      const buttonDiv = component.find('div');
+      assert.equal(buttonDiv.prop('tabIndex'), -1);
+    });
+
     it('should trigger onClick when enabled', () => {
       const ButtonComponent = component.find(Button);
 
@@ -47,6 +52,8 @@ describe('<TooltipButton />', () => {
       const TooltipComponent = wrapper.find(Tooltip);
       const ButtonComponent = component.find(Button);
 
+      const buttonDiv = wrapper.find('div');
+      assert.equal(buttonDiv.prop('tabIndex'), 0);
       assert(TooltipComponent.exists());
       ButtonComponent.simulate('click');
       sinon.assert.notCalled(dontCall);


### PR DESCRIPTION
Disabled elements aren't interactive, so keyboard users can't see tooltips on disabled elements. This PR adds a `tabindex` to the wrapper element when the button is disabled so keyboard users can see tooltips.

The bootstrap documents also recommend doing this:
https://getbootstrap.com/docs/4.5/components/tooltips/#disabled-elements

Not sure if these tooltips are currently announced to screenreaders, but that might be a future TODO
https://getbootstrap.com/docs/4.5/components/tooltips/#markup