### PR TITLE
Major version update to date-fns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11400,9 +11400,9 @@
       }
     },
     "date-fns": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
-      "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw=="
+      "version": "2.23.0",
+      "resolved": "https://registry.nlark.com/date-fns/download/date-fns-2.23.0.tgz",
+      "integrity": "sha1-TohslBZZrwz3sw+v3R6qN+iHiKk="
     },
     "date-now": {
       "version": "0.1.4",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@types/uniqid": "^4.1.3",
     "classnames": "^2.2.6",
     "credit-card-type": "^5.0.1",
-    "date-fns": "^1.30.1",
+    "date-fns": "^2.15.0",
     "deprecated-prop-type": "^1.0.0",
     "fast-deep-equal": "^3.1.3",
     "fecha": "^2.3.3",

--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -1,19 +1,21 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
-import addWeeks from 'date-fns/add_weeks';
-import eachDay from 'date-fns/each_day';
-import endOfWeek from 'date-fns/end_of_week';
-import format from 'date-fns/format';
-import isFuture from 'date-fns/is_future';
-import isPast from 'date-fns/is_past';
-import isSameDay from 'date-fns/is_same_day';
-import isSameMonth from 'date-fns/is_same_month';
-import isToday from 'date-fns/is_today';
-import startOfDay from 'date-fns/start_of_day';
-import startOfMonth from 'date-fns/start_of_month';
-import startOfWeek from 'date-fns/start_of_week';
-import enLocale from 'date-fns/locale/en';
+import {
+  addWeeks,
+  eachDayOfInterval,
+  endOfWeek,
+  isFuture,
+  isPast,
+  isSameDay,
+  isSameMonth,
+  isToday,
+  startOfDay,
+  startOfMonth,
+  startOfWeek,
+} from 'date-fns';
+import enLocale from 'date-fns/locale/en-US';
+import { format } from '../util/date.js';
 import Table from './Table';
 
 const Day = ({ day, dateFormat, locale, onClick, ...props }) => {
@@ -80,7 +82,7 @@ class Calendar extends React.Component {
   static defaultProps = {
     className: '',
     date: new Date(),
-    dateFormat: 'D',
+    dateFormat: 'd',
     dateEnabled: () => true,
     dateVisible: () => true,
     locale: enLocale,
@@ -93,7 +95,7 @@ class Calendar extends React.Component {
         onClick={() => day.visible && onSelect(day.date)}
       />
     ),
-    weekDayFormat: 'dd',
+    weekDayFormat: 'EEEEEE',
     onSelect: () => {}
   };
 
@@ -104,7 +106,7 @@ class Calendar extends React.Component {
     const end = endOfWeek(addWeeks(start, 5));
 
     // Generate calendar days:
-    return eachDay(start, end).map((date) => {
+    return eachDayOfInterval({ start, end }).map((date) => {
       return {
         selected: isSameDay(currentDate, date),
         date: startOfDay(date),

--- a/src/components/DateInput.js
+++ b/src/components/DateInput.js
@@ -1,16 +1,17 @@
 import PropTypes from 'prop-types';
 import deprecated from 'deprecated-prop-type';
 import React from 'react';
-import addDays from 'date-fns/add_days';
-import addMonths from 'date-fns/add_months';
-import addWeeks from 'date-fns/add_weeks';
-import addYears from 'date-fns/add_years';
-import Fecha from 'fecha'; // TODO replace with date-fns/parse after v2 is released
-import format from 'date-fns/format';
-import isSameDay from 'date-fns/is_same_day';
-import isValid from 'date-fns/is_valid';
-import startOfToday from 'date-fns/start_of_today';
-import enLocale from 'date-fns/locale/en';
+import {
+  addDays,
+  addMonths,
+  addWeeks,
+  addYears,
+  isSameDay,
+  isValid,
+  startOfToday
+} from 'date-fns';
+import enLocale from 'date-fns/locale/en-US';
+import { format, parse } from '../util/date.js';
 import Button from './Button';
 import ButtonGroup from './ButtonGroup';
 import Calendar from './Calendar';
@@ -21,16 +22,14 @@ import InputGroup from './InputGroup';
 import InputGroupAddon from './InputGroupAddon';
 import DropdownToggle from './DropdownToggle';
 
-const { parse } = Fecha;
-
 /**
  * Given a defaultValue, return the corresponding calendar date and input string value:
  *
  * | defaultValue   | date  | string         |
  * |----------------|-------|----------------|
  * | null,          | today | ''             |
- * | Date           | Date  | 'M/D/YYYY'     |
- * | 'M/D/YYYY'     | Date  | 'M/D/YYYY'     |
+ * | Date           | Date  | 'M/d/yyyy'     |
+ * | 'M/d/yyyy'     | Date  | 'M/d/yyyy'     |
  * | invalid string | today | invalid string |
  */
 function parseValue(defaultValue, dateFormat, parseDate) {
@@ -90,7 +89,7 @@ export default class DateInput extends React.Component {
 
   static defaultProps = {
     className: '',
-    dateFormat: 'M/D/YYYY',
+    dateFormat: 'M/d/yyyy',
     dateEnabled: () => true,
     dateVisible: () => true,
     disabled: false,
@@ -325,7 +324,7 @@ export default class DateInput extends React.Component {
                 </ButtonGroup>
 
                 <span className="js-date-header m-auto">
-                  {format(date, 'MMMM YYYY', { locale })}
+                  {format(date, 'MMMM yyyy', { locale })}
                 </span>
 
                 <ButtonGroup size="sm">

--- a/src/components/MonthCalendar.js
+++ b/src/components/MonthCalendar.js
@@ -1,15 +1,13 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import Fecha from 'fecha'; // TODO replace with date-fns/parse after v2 is released
 import Nav from './Nav';
 import NavItem from './NavItem';
 import NavLink from './NavLink';
 import Col from './Col';
 import Row from './Row';
+import { format } from '../util/date.js';
 import mod from '../util/mod.js';
 import range from '../util/range';
-
-const { format } = Fecha;
 
 const Label = ({ selected, label, onClick, visible = true }) => (
   <NavItem className={!visible ? 'invisible' : ''}>
@@ -46,7 +44,7 @@ export default class MonthCalendar extends React.Component {
     date: new Date(),
     dateVisible: () => true,
     monthFormat: 'MMM',
-    yearFormat: 'YYYY',
+    yearFormat: 'yyyy',
     onSelect: () => {}
   };
 

--- a/src/components/MonthInput.js
+++ b/src/components/MonthInput.js
@@ -1,11 +1,12 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import addMonths from 'date-fns/add_months';
-import addYears from 'date-fns/add_years';
-import Fecha from 'fecha'; // TODO replace with date-fns/parse after v2 is released
-import format from 'date-fns/format';
-import isSameDay from 'date-fns/is_same_day';
-import isValid from 'date-fns/is_valid';
+import {
+  addMonths,
+  addYears,
+  isSameDay,
+  isValid,
+} from 'date-fns';
+import { format, parse } from '../util/date.js';
 import Button from './Button';
 import ButtonGroup from './ButtonGroup';
 import Calendar from './MonthCalendar';
@@ -16,8 +17,6 @@ import Icon from './Icon';
 import InputGroup from './InputGroup';
 import InputGroupAddon from './InputGroupAddon';
 
-const { parse } = Fecha;
-
 // This is basically same as DateInput - maybe consider Dropdown+Input that encapsulates focus/blur/dropdown behavior?
 
 /**
@@ -26,8 +25,8 @@ const { parse } = Fecha;
  * | defaultValue   | date  | string         |
  * |----------------|-------|----------------|
  * | null,          | today | ''             |
- * | Date           | Date  | 'MMM YYYY'     |
- * | 'MMM YYYY'     | Date  | 'MMM YYYY'     |
+ * | Date           | Date  | 'MMM yyyy'     |
+ * | 'MMM yyyy'     | Date  | 'MMM yyyy'     |
  * | invalid string | today | invalid string |
  */
 function parseValue(defaultValue, dateFormat, parseDate) {
@@ -83,15 +82,15 @@ export default class MonthInput extends React.Component {
 
   static defaultProps = {
     className: '',
-    dateFormat: 'MMM YYYY',
+    dateFormat: 'MMM yyyy',
     dateVisible: () => true,
     disabled: false,
     keyboard: true,
     monthFormat: 'MMM',
-    yearFormat: 'YYYY',
+    yearFormat: 'yyyy',
     onBlur: () => {},
     onChange: () => {},
-    parse: (value, dateFormat) => parse(value, dateFormat),
+    parse: (value, dateFormat) => parse(value, dateFormat, new Date()),
     showOnFocus: true
   }
 
@@ -287,7 +286,7 @@ export default class MonthInput extends React.Component {
                 </ButtonGroup>
 
                 <span className="m-auto">
-                  {format(date, 'MMMM YYYY')}
+                  {format(date, 'MMMM yyyy')}
                 </span>
 
                 <ButtonGroup size="sm">

--- a/src/components/TimeInput.js
+++ b/src/components/TimeInput.js
@@ -1,26 +1,22 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import addMinutes from 'date-fns/add_minutes';
-import addSeconds from 'date-fns/add_seconds';
-import fecha from 'fecha';
-import getHours from 'date-fns/get_hours';
-import getMinutes from 'date-fns/get_minutes';
-import isBefore from 'date-fns/is_before';
-import setHours from 'date-fns/set_hours';
-import setMinutes from 'date-fns/set_minutes';
-import startOfToday from 'date-fns/start_of_today';
-import startOfTomorrow from 'date-fns/start_of_tomorrow';
-
+import {
+  addMinutes,
+  addSeconds,
+  getHours,
+  getMinutes,
+  isBefore,
+  setHours,
+  setMinutes,
+  startOfToday,
+  startOfTomorrow
+} from 'date-fns';
 import flow from 'lodash.flow';
 import toLower from 'lodash.tolower';
-
 import memoizeOne from 'memoize-one';
-
+import { format, parse } from '../util/date.js';
 import Icon from './Icon';
 import Select from './Select';
-
-const format = fecha.format;
-const parse = fecha.parse;
 
 const INVALID_DATE = new Date(undefined);
 
@@ -102,7 +98,7 @@ export default class TimeInput extends React.Component {
     onChange: () => {},
     step: 30,
     placeholder: 'Enter a time',
-    timeFormat: 'h:mm A',
+    timeFormat: 'h:mm a',
     noResultsText: 'Must be in the format HH:MM AM/PM'
   }
 

--- a/src/util/date.js
+++ b/src/util/date.js
@@ -1,0 +1,21 @@
+import * as DateFns from 'date-fns';
+
+export function isValidDate(date) {
+  return date instanceof Date && !Number.isNaN(date.getTime());
+}
+
+export function format(date, dateFormat, options = {}) {
+  return DateFns.format(date, dateFormat, options);
+}
+
+export function parse(value, dateFormat) {
+  // Mimics behavior of fecha.parse where invalid or blank value returns null.
+  const result = DateFns.parse(value, dateFormat, new Date());
+  return isValidDate(result) ? result : null;
+}
+
+export default {
+  format,
+  isValidDate,
+  parse
+};

--- a/test/components/Calendar.spec.js
+++ b/test/components/Calendar.spec.js
@@ -2,11 +2,13 @@ import React from 'react';
 import assert from 'assert';
 import { mount } from 'enzyme';
 import sinon from 'sinon';
-import addWeeks from 'date-fns/add_weeks';
-import endOfWeek from 'date-fns/end_of_week';
-import isSameDay from 'date-fns/is_same_day';
-import startOfMonth from 'date-fns/start_of_month';
-import startOfWeek from 'date-fns/start_of_week';
+import {
+  addWeeks,
+  endOfWeek,
+  isSameDay,
+  startOfMonth,
+  startOfWeek
+} from 'date-fns';
 import frLocale from 'date-fns/locale/fr';
 import { assertAccessible } from '../a11yHelpers';
 import { Calendar } from '../../src';
@@ -130,6 +132,7 @@ describe('<Calendar />', () => {
       const names = ['di', 'lu', 'ma', 'me', 'je', 've', 'sa'];
 
       names.forEach((w, i) => {
+        console.log('weekdays', weekdays.at(i));
         assert.strictEqual(weekdays.at(i).text(), w);
       });
     });

--- a/test/components/DateInput.spec.js
+++ b/test/components/DateInput.spec.js
@@ -1,13 +1,15 @@
 import React from 'react';
 import assert from 'assert';
 import { mount } from 'enzyme';
-import addDays from 'date-fns/add_days';
-import addMonths from 'date-fns/add_months';
-import addWeeks from 'date-fns/add_weeks';
-import addYears from 'date-fns/add_years';
-import isSameDay from 'date-fns/is_same_day';
-import isToday from 'date-fns/is_today';
-import startOfToday from 'date-fns/start_of_today';
+import {
+  addDays,
+  addMonths,
+  addWeeks,
+  addYears,
+  isSameDay,
+  isToday,
+  startOfToday
+} from 'date-fns';
 import frLocale from 'date-fns/locale/fr';
 import sinon from 'sinon';
 
@@ -473,8 +475,8 @@ describe('<DateInput />', () => {
 
   it('should call custom parse function', () => {
     const callback = sinon.spy(() => new Date(2003, 0, 2));
-    mount(<DateInput parse={callback} defaultValue="1-2-3" dateFormat="MM-DD-YY" />);
-    assert(callback.calledWith('1-2-3', 'MM-DD-YY'));
+    mount(<DateInput parse={callback} defaultValue="1-2-3" dateFormat="MM-dd-yy" />);
+    assert(callback.calledWith('1-2-3', 'MM-dd-yy'));
   });
 
   it('should support focus', () => {

--- a/test/components/MonthCalendar.spec.js
+++ b/test/components/MonthCalendar.spec.js
@@ -2,9 +2,8 @@ import React from 'react';
 import assert from 'assert';
 import { mount } from 'enzyme';
 import sinon from 'sinon';
-import fecha from 'fecha';
-import isBefore from 'date-fns/is_before';
-import isSameDay from 'date-fns/is_same_day';
+import { isBefore, isSameDay } from 'date-fns';
+import { format } from '../../src/util/date.js';
 import { MonthCalendar } from '../../src';
 
 describe('<MonthCalendar />', () => {
@@ -19,7 +18,7 @@ describe('<MonthCalendar />', () => {
     const today = new Date();
     const month = component.find('.active').first();
     const year = component.find('.active').last();
-    assert.equal(month.text(), fecha.format(today, 'MMM'));
+    assert.equal(month.text(), format(today, 'MMM'));
     assert.equal(year.text(), today.getFullYear());
   });
 
@@ -28,7 +27,7 @@ describe('<MonthCalendar />', () => {
     const component = mount(<MonthCalendar date={date} />);
     const month = component.find('.active').first();
     const year = component.find('.active').last();
-    assert.equal(month.text(), fecha.format(date, 'MMM'));
+    assert.equal(month.text(), format(date, 'MMM'));
     assert.equal(year.text(), date.getFullYear());
   });
 

--- a/test/components/MonthInput.spec.js
+++ b/test/components/MonthInput.spec.js
@@ -1,11 +1,13 @@
 import React from 'react';
 import assert from 'assert';
 import { mount } from 'enzyme';
-import addMonths from 'date-fns/add_months';
-import addYears from 'date-fns/add_years';
-import isSameDay from 'date-fns/is_same_day';
-import isSameMonth from 'date-fns/is_same_month';
-import isToday from 'date-fns/is_today';
+import {
+  addMonths,
+  addYears,
+  isSameDay,
+  isSameMonth,
+  isToday
+} from 'date-fns';
 import sinon from 'sinon';
 
 import { MonthInput } from '../../src';
@@ -290,8 +292,8 @@ describe('<MonthInput />', () => {
 
   it('should call custom parse function', () => {
     const callback = sinon.spy(() => new Date(2003, 0, 2));
-    mount(<MonthInput parse={callback} defaultValue="1-2-3" dateFormat="MM-DD-YY" />);
-    assert(callback.calledWith('1-2-3', 'MM-DD-YY'));
+    mount(<MonthInput parse={callback} defaultValue="1-2-3" dateFormat="MM-dd-yy" />);
+    assert(callback.calledWith('1-2-3', 'MM-dd-yy'));
   });
 
   describe('accessibility', () => {

--- a/test/components/TimeInput.spec.js
+++ b/test/components/TimeInput.spec.js
@@ -2,8 +2,7 @@ import React from 'react';
 import assert from 'assert';
 import { mount } from 'enzyme';
 import sinon from 'sinon';
-import isSameDay from 'date-fns/is_same_day';
-
+import { isSameDay } from 'date-fns';
 import { TimeInput, Select } from '../../src';
 
 const VALUE_SELECTOR = '[aria-selected="true"]';
@@ -69,7 +68,7 @@ describe('<TimeInput />', () => {
   it('should format values with specified timeFormat', () => {
     const component = mount(<TimeInput timeFormat="hh:mm a" defaultValue="16:30" />);
     const options = component.find(Select).prop('options');
-    assert.equal(options[33].label, '04:30 pm');
+    assert.equal(options[33].label, '04:30 PM');
     assert.equal(options[33].value, '16:30');
   });
 

--- a/test/typesafety.tsx
+++ b/test/typesafety.tsx
@@ -401,9 +401,9 @@ const LabelBadgeExample = () => {
 
 const MonthInputExample = () => {
   <MonthInput
-    dateFormat="MMM YYYY"
+    dateFormat="MMM yyyy"
     monthFormat="MMM"
-    yearFormat="YYY"
+    yearFormat="yyyy"
     showOnFocus={true}
     disabled={false}
     onBlur={() => {}}

--- a/test/util/date.spec.js
+++ b/test/util/date.spec.js
@@ -1,0 +1,50 @@
+import assert from 'assert';
+import * as DateUtils from '../../src/util/date.js';
+
+describe('date', () => {
+  describe('#format', () => {
+    it('uses date-fns format', () => {
+      assert.equal(DateUtils.format(new Date(2017, 7, 14), 'MM/dd/yyyy'), '08/14/2017');
+    });
+  });
+
+  describe('#isValidDate', () => {
+    it('returns true when date is valid', () => {
+      assert.equal(DateUtils.isValidDate(new Date(2017, 7, 14)), true);
+    });
+
+    it('returns false when date is null', () => {
+      assert.equal(DateUtils.isValidDate(null), false);
+    });
+
+    it('returns false when date is undefined', () => {
+      assert.equal(DateUtils.isValidDate(undefined), false);
+    });
+
+    it('returns false when date is invalid', () => {
+      assert.equal(DateUtils.isValidDate(new Date(undefined)), false);
+    });
+  });
+
+  describe('#parse', () => {
+    it('returns null when date is null', () => {
+      assert.equal(DateUtils.parse(null, 'MM/dd/yyyy'), null);
+    });
+
+    it('returns null when date is undefined', () => {
+      assert.equal(DateUtils.parse(undefined, 'MM/dd/yyyy'), null);
+    });
+
+    it('returns null when date is blank', () => {
+      assert.equal(DateUtils.parse(undefined, 'MM/dd/yyyy'), null);
+    });
+
+    it('returns null when date is unparsable', () => {
+      assert.equal(DateUtils.parse('What a date!', 'MM/dd/yyyy'), null);
+    });
+
+    it('uses date-fns format', () => {
+      assert.equal(DateUtils.parse('08/14/2017', 'MM/dd/yyyy').toString(), new Date(2017, 7, 14).toString());
+    });
+  });
+});


### PR DESCRIPTION
During Hack Day, I was planning to put some code into `react-gears` that required `date-fns-tz` to perform timezone operations, and this module requires `date-fns` 2.0.0 or greater.  As a result, I spent some time to see what it would take to perform that update, and the result is this PR.

Unfortunately, because `react-gears` exposes the date format in a couple places, and the new version of `date-fns` deprecates some of the previous formatting rules in favor of UNICODE standards (for example, "year" changed from `Y` to `y` syntax, day from `D` to `d` and AM/PM from `A` to `a`), `react-gears` clients that specify date formats for affected components will be impacted.

In the end, I found a better home for my time-zone-respecting components, so this update is not required, but it still may be desired to keep `react-gears` up-to-date.

As such, I present this PR as a draft to demonstrate the changes that will be required to update to `date-fns` 2.15.0.  I leave it to the `react-gears` dev team to do with this what they will.  😄 