### PR TITLE
use popper modifier to set max height so directions still work

### DIFF
--- a/src/components/Combobox.tsx
+++ b/src/components/Combobox.tsx
@@ -11,11 +11,7 @@ import Input from './Input';
 import InputGroup from './InputGroup';
 import InputGroupAddon from './InputGroupAddon';
 
-type Direction =
-  | 'up'
-  | 'down'
-  | 'left'
-  | 'right';
+type Direction = 'up' | 'down';
 
 type Option = {
   label: string;
@@ -189,9 +185,20 @@ const Combobox: React.FunctionComponent<ComboboxProps> = ({
       <DropdownMenu
         data-testid="combobox-menu"
         className="p-0 w-100"
-        style={{
-          maxHeight: menuMaxHeight || '12rem',
-          overflowY: 'auto'
+        modifiers={{
+          setMaxHeight: {
+            enabled: true,
+            fn: (data) => {
+              return {
+                ...data,
+                styles: {
+                  ...data.styles,
+                  overflowY: 'auto',
+                  maxHeight: menuMaxHeight || '12rem',
+                },
+              };
+            },
+          },
         }}
         {...dropdownProps}
         ref={dropdownMenu}

--- a/stories/Combobox.js
+++ b/stories/Combobox.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
-import { boolean, text } from '@storybook/addon-knobs';
+import { boolean, text, select } from '@storybook/addon-knobs';
 import { Combobox, Icon } from '../src';
 
 const options = [
@@ -72,6 +72,7 @@ storiesOf('Combobox', module)
     const [value, setValue] = useState();
     return (
       <Combobox
+        direction={select('direction', ['', 'down', 'up'], '')}
         onChange={setValue}
         options={options}
         value={value}


### PR DESCRIPTION
This PR adds a custom popper modifier to set the max height of the combobox options menu in place of the old `style` property. The `style` property prevented popper directions from working correctly.

### Old Behavior
Options always show up below the input box.

### New Behavior
Options show up below the input box be default, and above if there's no room below. Consumer can also specify if they want the options to show up above the input box.