### PR TITLE
fix incorrect type declaration files

### DIFF
--- a/src/components/CheckboxInput.tsx
+++ b/src/components/CheckboxInput.tsx
@@ -21,8 +21,8 @@ type CheckboxBooleanInputProps = ExtendsWithTypeOverrides<InputProps, CheckboxBo
 type CheckboxInputProps = CheckboxListInputProps | CheckboxBooleanInputProps;
 
 const CheckboxInput: FunctionComponent<CheckboxInputProps> = (props: CheckboxInputProps) =>
-    props.children ?
-      <CheckboxListInput {...props} /> :
-      <CheckboxBooleanInput {...(props as CheckboxBooleanInputProps)} />;
+  props.children ?
+    <CheckboxListInput {...props as CheckboxListInputProps} /> :
+    <CheckboxBooleanInput {...props as CheckboxBooleanInputProps} />;
 
 export default CheckboxInput;

--- a/src/components/CheckboxListInput.d.ts
+++ b/src/components/CheckboxListInput.d.ts
@@ -6,5 +6,5 @@ interface CheckboxListInputProps {
   value?: string[];
 }
 
-declare class CheckboxListInput extends Component<CheckboxBooleanInputProps, {}> { }
+declare class CheckboxListInput extends Component<CheckboxListInputProps, {}> { }
 export default CheckboxListInput;

--- a/src/components/CollapsableText.d.ts
+++ b/src/components/CollapsableText.d.ts
@@ -3,9 +3,9 @@ import * as React from 'react';
 export interface CollapsableTextProps {
   children?: string;
   collapsed?: boolean;
-  lessLabel?: ReactNode;
+  lessLabel?: React.ReactNode;
   maxLength?: number;
-  moreLabel?: ReactNode;
+  moreLabel?: React.ReactNode;
 }
 
 export default class CollapsableText extends React.Component<CollapsableTextProps, any> {

--- a/src/components/ConfirmationButton.d.ts
+++ b/src/components/ConfirmationButton.d.ts
@@ -2,9 +2,9 @@ import * as React from 'react';
 import Button from './Button';
 
 interface ConfirmationButtonProps extends Button {
-  children?: ReactNode;
+  children?: React.ReactNode;
   confirmation?: string
   onClick?: (...args: any[]) => any;
 }
-declare class ConfirmationButton extends Component<ConfirmationButtonProps, {}> { }
+declare class ConfirmationButton extends React.Component<ConfirmationButtonProps, {}> { }
 export default ConfirmationButton;

--- a/src/components/FeatureBanner.d.ts
+++ b/src/components/FeatureBanner.d.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 interface FeatureBannerProps {
   alertText?: string;
-  children?: ReactNode;
+  children?: React.ReactNode;
   color?: string;
   subtitle: string;
   title: string;

--- a/src/components/FormRow.d.ts
+++ b/src/components/FormRow.d.ts
@@ -2,8 +2,8 @@ import * as React from 'react';
 
 interface FormRowPropTypes extends
   Omit<React.HTMLAttributes<HTMLInputElement>, 'id'>{
-  children?: ReactNode;
-  label?: ReactNode;
+  children?: React.ReactNode;
+  label?: React.ReactNode;
   labelSize?: string;
   hint?: string;
   feedback?: any;
@@ -14,7 +14,7 @@ interface FormRowPropTypes extends
   inline?: boolean;
   stacked?: boolean;
   size?: string;
-  validFeedback?: ReactNode;
+  validFeedback?: React.ReactNode;
   width?: {
     size?: boolean | number | string
     push?: string | number

--- a/src/components/HasManyFieldsAdd.d.ts
+++ b/src/components/HasManyFieldsAdd.d.ts
@@ -3,7 +3,7 @@ import * as React from 'react';
 
 interface HasManyFieldsAddProps extends Omit<ButtonProps,'color'> {
   className?: string;
-  children: ReactNode;
+  children: React.ReactNode;
   disabled?: boolean;
 }
 declare class HasManyFieldsAdd extends React.Component<HasManyFieldsAddProps, {}> { }

--- a/src/components/HasManyFieldsRow.d.ts
+++ b/src/components/HasManyFieldsRow.d.ts
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
 interface HasManyFieldsRowProps {
-  children: ReactNode;
+  children: React.ReactNode;
   className?: string;
   onDelete?: React.MouseEventHandler<any>;
   deletable?: boolean;
   disabled?: boolean;
-  disabledReason?: ReactNode;
+  disabledReason?: React.ReactNode;
   disabledReasonPlacement?: string;
 }
 declare class HasManyFieldsRow extends React.Component<HasManyFieldsRowProps, {}> { }

--- a/src/components/HelpBubble.d.ts
+++ b/src/components/HelpBubble.d.ts
@@ -3,7 +3,7 @@ import * as React from 'react';
 
 interface HelpBubbleProps extends Omit<PopoverProps, 'isOpen' | 'toggle' | 'target'> {
   title: string;
-  children?: ReactNode;
+  children?: React.ReactNode;
   className?: string;
 }
 declare class HelpBubble extends React.Component<HelpBubbleProps, {}> { }

--- a/src/components/InfoBox.d.ts
+++ b/src/components/InfoBox.d.ts
@@ -4,7 +4,7 @@ interface InfoBoxProps extends
   Omit<React.HTMLProps<HTMLDivElement>, 'className'>{
   className?: string;
   color?: string;
-  children: ReactNode;
+  children: React.ReactNode;
   icon?: string;
   title?: string;
   vertical: boolean;

--- a/src/components/LabelBadge.d.ts
+++ b/src/components/LabelBadge.d.ts
@@ -6,7 +6,7 @@ interface LabelBadgeProps {
   maxWidth?: number;
   onRemove?: React.MouseEventHandler<any>;
   removable?: boolean;
-  value: ReactNode;
+  value: React.ReactNode;
 }
 declare class LabelBadge extends React.Component<LabelBadgeProps, {}> { }
 export default LabelBadge;

--- a/src/components/MonthInput.d.ts
+++ b/src/components/MonthInput.d.ts
@@ -8,8 +8,8 @@ interface MonthInputProps {
   yearFormat?: string;
   defaultValue?: string | Date;
   disabled?: boolean;
-  footer?: ReactNode;
-  header?: ReactNode;
+  footer?: React.ReactNode;
+  header?: React.ReactNode;
   keyboard?: boolean;
   onBlur?: (e: React.FocusEvent<HTMLInputElement>) => void;
   onChange?: (val: Date | string, isDate: boolean) => void;

--- a/src/components/PopperContent.d.ts
+++ b/src/components/PopperContent.d.ts
@@ -1,2 +1,27 @@
-import PopperContent from 'reactstrap/lib/PopperContent';
+import React from 'react';
+type Target = string | ((...args: any[]) => any) | Element | { current: any };
+type Tag = ((...args: any[]) => any) | string | React.Component;
+interface PopperContentProps extends React.HTMLAttributes<HTMLElement> {
+  [key: string]: any;
+  popperClassName?: string;
+  placement?: string;
+  placementPrefix?: string;
+  arrowClassName?: string;
+  hideArrow?: boolean;
+  tag?: Tag | Tag[];
+  isOpen: boolean;
+  cssModule?: object;
+  offset?: string | number;
+  fallbackPlacement?: string | any[];
+  flip?: boolean;
+  container?: Target;
+  target: Target;
+  modifiers?: object;
+  boundariesElement?: string | Element;
+  onClosed?: (...args: any[]) => any;
+  fade?: boolean;
+  transition?: any;
+}
+
+declare class PopperContent extends React.Component<PopperContentProps, {}> {}
 export default PopperContent;

--- a/src/components/PopperTargetHelper.d.ts
+++ b/src/components/PopperTargetHelper.d.ts
@@ -1,2 +1,4 @@
-import PopperTargetHelper from 'reactstrap/lib/PopperTargetHelper';
+import React from 'react';
+type Target = string | ((...args: any[]) => any) | Element | { current: any };
+declare class PopperTargetHelper extends React.Component<{ target: Target }, {}> {}
 export default PopperTargetHelper;

--- a/src/components/Portal.d.ts
+++ b/src/components/Portal.d.ts
@@ -1,2 +1,4 @@
-import Portal from 'reactstrap/lib/Portal';
+import React from 'react';
+declare class Portal extends React.Component<{}, {}> {}
 export default Portal;
+

--- a/src/components/UncontrolledAlert.d.ts
+++ b/src/components/UncontrolledAlert.d.ts
@@ -1,2 +1,2 @@
-import UncontrolledAlert from 'reactstrap/lib/UncontrolledAlert';
+import { UncontrolledAlert } from 'reactstrap/lib/Uncontrolled';
 export default UncontrolledAlert;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,8 +8,7 @@
     "isolatedModules": true,
     "esModuleInterop": true,
     "jsx": "react",
-    "experimentalDecorators": true,
-    "skipLibCheck": true // needed for .d.ts files TODO remove if all .ts
+    "experimentalDecorators": true
   },
   "include": ["src"]
 }


### PR DESCRIPTION
Many of the type declaration files were not semantically correct. This
was not caught when running the tslint script due to the skipLibCheck
flag in the tsconfig. This flag skips type checking on all type
declaration files. Due to the incorrect types, downstream projects have
to also turn on the skipLibCheck flag when using react-gears, even
if they do not use the modules with broken types.