### PR TITLE
yl - Fix <HelpBubble /> title type

### DIFF
--- a/src/components/HelpBubble.d.ts
+++ b/src/components/HelpBubble.d.ts
@@ -2,7 +2,7 @@ import { PopoverProps } from 'reactstrap/lib/Popover';
 import * as React from 'react';
 
 interface HelpBubbleProps extends Omit<PopoverProps, 'isOpen' | 'toggle' | 'target'> {
-  title: string;
+  title: React.ReactNode;
   children?: React.ReactNode;
   className?: string;
 }

--- a/src/components/HelpBubble.js
+++ b/src/components/HelpBubble.js
@@ -65,7 +65,7 @@ class HelpBubble extends React.Component {
 }
 
 HelpBubble.propTypes = {
-  title: PropTypes.string.isRequired,
+  title: PropTypes.node.isRequired,
   children: PropTypes.node,
   className: PropTypes.any
 };


### PR DESCRIPTION
This is for fixing <HelpBubble /> title prop propTypes and TS type definition.

It should allow same input as children prop while currently it is defined to be string only.

Example usage that gets prop type warning:
https://github.com/appfolio/apm_bundle/blob/0d0d064d4481f88e04ef282ada37d806256bdaa7/apps/property/app/javascript/prepare_lease_renewal/src/components/sections/renewalOptions/leaseRenewalOption/respondByDate/presenter.js#L19