### PR TITLE
Should return startOfToday when click on Today button in DateInput

### DIFF
--- a/src/components/DateInput.js
+++ b/src/components/DateInput.js
@@ -8,6 +8,7 @@ import Fecha from 'fecha'; // TODO replace with date-fns/parse after v2 is relea
 import format from 'date-fns/format';
 import isSameDay from 'date-fns/is_same_day';
 import isValid from 'date-fns/is_valid';
+import startOfToday from 'date-fns/start_of_today';
 import Button from './Button';
 import ButtonGroup from './ButtonGroup';
 import Calendar from './Calendar';
@@ -203,7 +204,7 @@ export default class DateInput extends React.Component {
   prevMonth = () => this.setDate(addMonths(this.getCurrentDate(), -1));
   prevYear = () => this.setDate(addYears(this.getCurrentDate(), -1));
   show = () => this.setState({ open: true });
-  today = () => this.setDate(new Date(), true);
+  today = () => this.setDate(startOfToday(), true);
   toggle = () => (this.state.open ? this.close() : this.show());
 
   setInputValue = () => {

--- a/test/components/DateInput.spec.js
+++ b/test/components/DateInput.spec.js
@@ -7,6 +7,7 @@ import addWeeks from 'date-fns/add_weeks';
 import addYears from 'date-fns/add_years';
 import isSameDay from 'date-fns/is_same_day';
 import isToday from 'date-fns/is_today';
+import startOfToday from 'date-fns/start_of_today';
 import sinon from 'sinon';
 
 import { DateInput } from '../../src';
@@ -220,10 +221,10 @@ describe('<DateInput />', () => {
       assert(isSameDay(callback.firstCall.args[0], expectedDate));
     });
 
-    it('should should set date after clicking today', () => {
+    it('should set date to start of today after clicking today', () => {
       const today = component.find('footer Button').at(0);
       today.simulate('click');
-      assert(isToday(component.instance().getCurrentDate()));
+      assert.deepEqual(component.instance().getCurrentDate(), startOfToday());
     });
 
     it('should should call onChange after clicking today', () => {


### PR DESCRIPTION
This change makes DateInput's behavior of clicking **Today** button the same as clicking directly on the date. 

STR:
 - Go to DateInput in [React Gears storybook](https://appfolio.github.io/react-gears/?path=/story/dateinput--with-props)
 - Choose Actions on the right to monitor the value
 - Click on the calendar icon and click Today button

O:
 - Return a date like this "Nov 16 2020 **15:28:07** GMT-0800 (Pacific Standard Time)"

D:
 - Should return start of Today "Nov 16 2020 **00:00:00** GMT-0800 (Pacific Standard Time)"
 - This is the behavior when we click on the date directly on the calendar, and the behavior should be consistent.  


