### PR TITLE
Updates to closely mimic Saffron Activity Log

### DIFF
--- a/src/components/Activity.tsx
+++ b/src/components/Activity.tsx
@@ -11,7 +11,6 @@ interface ActivityProps extends Omit<ListGroupItemProps, 'action'> {
   children?: ReactNode;
   date: Date;
   dateFormat?: string;
-  shortDateFormat?: string;
 }
 
 /**
@@ -24,18 +23,19 @@ const Activity: FunctionComponent<ActivityProps> = ({
   children,
   date,
   dateFormat = 'MM/DD/YYYY hh:mm A',
-  shortDateFormat = 'M/D/YY h:mm A',
   ...props
 }) => (
   <ListGroupItem {...props}>
-    <Row className="w-100 no-gutters">
-      <Col xs={12} sm={3} className="text-nowrap text-truncate">
-        <span className="d-none d-md-inline">{fecha.format(date, dateFormat)}</span>
-        <span className="d-md-none">{fecha.format(date, shortDateFormat)}</span>
+    <Row className="w-100 no-gutters align-items-center">
+      <Col className="mr-2" style={{ maxWidth: '11em' }}>
+        <span className="d-none d-inline js-date">{fecha.format(date, dateFormat)}</span>
       </Col>
-      <Col className="pl-md-1">
+      {/* Force the next column to break to new line at the xs breakpoint; specifying `xs` in the first column
+        * does nothing since the max-width style seems to override the normal flexbox breakpoint behavior. */}
+      <div className="w-100 d-xs-block d-sm-none" />
+      <Col className="js-action">
         {(action || date) && (
-          <div className="text-truncate">
+          <div>
             {action && <strong>{action}</strong>}
             {by && (
               <span className="pl-1 js-by">

--- a/test/components/Activity.spec.js
+++ b/test/components/Activity.spec.js
@@ -18,7 +18,7 @@ describe('<Activity />', () => {
 
   it('should render date', () => {
     const component = mount(<Activity date={new Date(2015, 1, 13, 12, 30)} />);
-    const date = component.find('span').first();
+    const date = component.find('.js-date').first();
     assert.strictEqual(date.text(), '02/13/2015 12:30 PM');
   });
 
@@ -47,7 +47,7 @@ describe('<Activity />', () => {
 
   it('should support custom date formats', () => {
     const component = mount(<Activity dateFormat="M/D/YYYY" date={new Date(2010, 4, 9)} />);
-    const date = component.find('span').first();
+    const date = component.find('.js-date').first();
     assert.strictEqual(date.text(), '5/9/2010');
   });
 });


### PR DESCRIPTION
Some qualities of `Activity` differ notably from the Saffron `activity_log`.  This brings them more inline:
* Uses static max-width for date column; the variable-width version presented a distinctive UX difference, and often took up additional horizontal space better utilized by the "_Action_ - _By_" column
* Make "_Action_ - _By_" wrap onto multiple lines; previous behavior truncated long lines, including the user information
* Remove short date format for date -- this is not an option supported in the Saffron `activity_log`
  * Remove `shortDateFormat` prop -- It is not used anywhere in APM

What to retain in the React implementation:
* Specific `xs` breakpoint for improved visibility on small screens / mobile devices