### PR TITLE
feat: pass thru className of FormChoice elements in a CheckboxListInput

### DIFF
--- a/src/components/CheckboxListInput.js
+++ b/src/components/CheckboxListInput.js
@@ -1,9 +1,10 @@
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 
 class CheckboxListInput extends React.Component {
   static propTypes = {
     children: PropTypes.node,
+    className: PropTypes.string,
     onChange: PropTypes.func,
     value: PropTypes.array
   };
@@ -28,12 +29,13 @@ class CheckboxListInput extends React.Component {
     const {
       value,
       children,
+      className,
       onChange,
       ...props
     } = this.props;
 
     return (
-      <div>
+      <div className={className}>
         {React.Children.map(children, choice => React.cloneElement(choice, {
           type: 'checkbox',
           selected: value,

--- a/src/components/FormChoice.js
+++ b/src/components/FormChoice.js
@@ -1,6 +1,7 @@
-import React from 'react';
-import PropTypes from 'prop-types';
 import classname from 'classnames';
+import PropTypes from 'prop-types';
+import React from 'react';
+
 import FormGroup from './FormGroup';
 import Input from './Input';
 import Label from './Label';
@@ -16,6 +17,7 @@ class FormChoice extends React.Component {
     inline: PropTypes.bool,
     disabled: PropTypes.bool,
     children: PropTypes.node,
+    containerClassName: PropTypes.string,
     id: PropTypes.string,
     type: PropTypes.oneOf(['checkbox', 'radio', 'select']),
     value: PropTypes.any
@@ -32,6 +34,7 @@ class FormChoice extends React.Component {
       inline,
       disabled,
       children,
+      containerClassName,
       type,
       value,
       ...attributes
@@ -45,12 +48,12 @@ class FormChoice extends React.Component {
       );
     }
 
-    const labelClasses = classname({ 'form-check-inline': inline });
+    const containerClasses = classname({ 'form-check-inline': inline }, containerClassName);
 
     const computedValue = value || children;
 
     const item = (
-      <div className={labelClasses}>
+      <div className={containerClasses}>
         <Input
           id={this.id}
           type={type}

--- a/test/components/FormChoice.spec.js
+++ b/test/components/FormChoice.spec.js
@@ -1,8 +1,9 @@
-import React from 'react';
 import assert from 'assert';
-import { shallow } from 'enzyme';
 
-import { Input, Label, FormGroup, FormChoice } from '../../src';
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import { FormChoice, FormGroup, Input, Label } from '../../src';
 
 describe('<FormChoice />', () => {
   describe('unknown type', () => {
@@ -62,6 +63,14 @@ describe('<FormChoice />', () => {
 
       assert.equal(component.find(Input).prop('type'), 'checkbox');
       assert.equal(component.find(Label).props().children, 'my type');
+    });
+
+    it('should pass on containerClassName as className', () => {
+      const component = shallow(
+        <FormChoice type="checkbox" containerClassName="myClass" inline>my type</FormChoice>
+      );
+
+      assert(/\bmyClass\b/.test(component.find('div').prop('className')));
     });
 
     describe('with computed value', () => {


### PR DESCRIPTION
This allows among other things to indent a checkbox (including label) in a single checkbox list.