### PR TITLE
Update <FeatureBanner /> subtitle type

### DIFF
--- a/src/components/FeatureBanner.d.ts
+++ b/src/components/FeatureBanner.d.ts
@@ -3,7 +3,7 @@ interface FeatureBannerProps {
   alertText?: string;
   children?: React.ReactNode;
   color?: string;
-  subtitle: string;
+  subtitle: React.ReactNode;
   title: string;
 }
 declare class FeatureBanner extends React.Component<FeatureBannerProps, {}> { }

--- a/src/components/FeatureBanner.js
+++ b/src/components/FeatureBanner.js
@@ -7,7 +7,7 @@ export default class FeatureBanner extends React.Component {
     alertText: PropTypes.string,
     children: PropTypes.node,
     color: PropTypes.string,
-    subtitle: PropTypes.string.isRequired,
+    subtitle: PropTypes.node.isRequired,
     title: PropTypes.string.isRequired,
   };
 
@@ -47,7 +47,7 @@ export default class FeatureBanner extends React.Component {
             .body @media (min-width: 576px) {
               border-left: 1px solid rgba(0, 0, 0, 0.1);
             }
-            
+
             .info {
               flex: 1 1 auto;
             }


### PR DESCRIPTION
With the previous type, if a user wants the subtitle to have a link
and passed in a react component.

E.g
```jsx
const subtitle = <span>More info in <a href={url}here</a>.</span>
<FeatureBanner
  alertText="New"
  subtitle={subtitle}
  title="Title"
/>
```

The user gets prop type warning or TypeScript error while it works
perfectly.

The type of subtitle prop of <FeatureBanner /> was string, while
it can be anything that can be rendered, which is PropTypes.node,
React.ReactNode.
https://github.com/appfolio/react-gears/blob/c0e0eebbead311527be3b8b119fc94c3dc7f3a3d/src/components/FeatureBanner.js#L35