### PR TITLE
Add index prop to HasManyFields Template

### DIFF
--- a/src/components/HasManyFields.js
+++ b/src/components/HasManyFields.js
@@ -178,6 +178,7 @@ class HasManyFields extends React.Component {
           errors={errors[index]}
           onChange={this.updateItem(index)}
           disabled={disabled}
+          index={index}
           {...refProps}
         />
       </HasManyFieldsRow>

--- a/test/components/HasManyFields.spec.js
+++ b/test/components/HasManyFields.spec.js
@@ -148,6 +148,12 @@ describe('<HasManyFields />', () => {
       });
     });
 
+    it('should pass the index to each template', () => {
+      component.find(Input).forEach((input, i) => {
+        assert.equal(input.prop('index'), i);
+      });
+    });
+
     it('should pass the errors to each template', () => {
       component.find(Input).forEach((input, i) => {
         assert.deepEqual(input.prop('errors'), errors[i]);


### PR DESCRIPTION
We have a new use case where we would like to use the current index to
display an index specific label on each row in HasMany fields. The index
was already available when rendering the template. This change just
passes it through.