### PR TITLE
Table style updates

### DIFF
--- a/src/components/SortableTable.js
+++ b/src/components/SortableTable.js
@@ -21,19 +21,22 @@ function defaultRenderRow(row, columns, rowClassName, rowExpanded, rowOnClick, t
   return [
     <tr
       key={row.key}
-      className={classnames({ 'table-info': rowSelected && rowSelected(row) }, rowClassName(row))}
+      className={classnames({ 'table-primary': rowSelected && rowSelected(row) }, rowClassName(row))}
       onClick={e => rowOnClick && rowOnClick(row, e)}
       role={rowOnClick ? 'button' : null}
     >
       {columns.map(column => (
         <td key={column.key} className={generateColumnClassName(column, truncate)}>
-          {column.cell(row)}
+          {column.cell(row, expanded)}
         </td>
       ))}
     </tr>,
     expanded && <tr key={row.key ? `${row.key}-hidden` : null} hidden />,
     expanded && (
-      <tr key={row.key ? `${row.key}-expanded` : null} className="tr-expanded">
+      <tr
+        key={row.key ? `${row.key}-expanded` : null}
+        className={classnames({ 'table-primary': rowSelected && rowSelected(row) }, 'tr-expanded')}
+      >
         <td className="border-top-0" colSpan={columns.length}>
           {expanded}
         </td>
@@ -151,13 +154,13 @@ class SortableTable extends React.Component {
       cols.push({
         align: 'center',
         key: 'expand',
-        cell: row => (
+        cell: (row, expanded) => (
           <Button
             className="px-2 py-0"
             color="link"
             onClick={() => onExpand(row)}
           >
-            <Icon name="ellipsis-v" size="lg" />
+            <Icon name={expanded ? 'angle-up' : 'angle-down'} />
             <span className="sr-only">Expand row</span>
           </Button>
         ),


### PR DESCRIPTION
- Selection color to "primary" instead of "info"
- Carry selection color to expanded row
- Change ellipsis icon to angle up/down for expandable row

<img width="830" alt="Screen Shot 2021-03-22 at 3 00 11 PM" src="https://user-images.githubusercontent.com/18536746/112063903-60403600-8b1f-11eb-95fe-f82473278723.png">
