### PR TITLE
fix notes component typing

### DIFF
--- a/src/components/Note.tsx
+++ b/src/components/Note.tsx
@@ -15,11 +15,11 @@ type NoteProps = {
   dateFormat?: string,
   showTimezone?: boolean,
   note: NoteType,
-  onCancel: (note: NoteType) => void,
-  onChange: React.ChangeEventHandler<HTMLInputElement>,
+  onCancel?: (note: NoteType) => void,
+  onChange?: React.ChangeEventHandler<HTMLInputElement>,
   onDelete?: (note: Omit<NoteType, 'text'>) => void,
   onEdit?: (note: Omit<NoteType, 'text'>) => void,
-  onSave: (note: NoteType) => void,
+  onSave?: (note: NoteType) => void,
   onUndelete?: (note: NoteType) => void,
   rows?: number,
   saving?: boolean,
@@ -63,7 +63,7 @@ const Note: React.FunctionComponent<NoteProps> = ({
         note={note}
         onUndelete={onUndelete}
       />);
-  } else if (editing) {
+  } else if (editing && onCancel && onChange && onSave) {
     return (
       <EditableNote
         className={className}
@@ -106,11 +106,11 @@ Note.propTypes = {
     errors: PropTypes.string,
     text: PropTypes.string.isRequired
   }).isRequired,
-  onCancel: PropTypes.func.isRequired,
-  onChange: PropTypes.func.isRequired,
+  onCancel: PropTypes.func,
+  onChange: PropTypes.func,
   onDelete: PropTypes.func,
   onEdit: PropTypes.func,
-  onSave: PropTypes.func.isRequired,
+  onSave: PropTypes.func,
   onUndelete: PropTypes.func,
   rows: PropTypes.number,
   saving: PropTypes.bool,

--- a/src/components/Notes.tsx
+++ b/src/components/Notes.tsx
@@ -7,11 +7,11 @@ import NoteType from './TypeHelpers/NoteType';
 type NotesProps = {
   children?: React.ReactNode,
   className?: string,
-  onCancel: (note: NoteType) => void,
-  onChange: React.ChangeEventHandler<HTMLInputElement>,
+  onCancel?: (note: NoteType) => void,
+  onChange?: React.ChangeEventHandler<HTMLInputElement>,
   onDelete?: (note: Omit<NoteType, 'text'>) => void,
   onEdit?: (note: Omit<NoteType, 'text'>) => void,
-  onSave: (note: NoteType) => void,
+  onSave?: (note: NoteType) => void,
   onUndelete?: (note: NoteType) => void,
   notes: (NoteType & { id: string, saving?: boolean, })[],
 }
@@ -19,29 +19,21 @@ type NotesProps = {
 const defaultProps = {
   className: '',
   notes: [],
-  onCancel: () => {},
-  onChange: () => {},
-  onSave: () => {},
 };
 
 const Notes: React.FunctionComponent<NotesProps> = ({
   className = defaultProps.className,
   notes = defaultProps.notes,
-  ...props
-}) => {
-  const {
-    children,
-    onCancel,
-    onChange,
-    onDelete,
-    onEdit,
-    onSave,
-    onUndelete
-  } = props;
-
-  return (
-    <div className={className}>
-      {children ||
+  children,
+  onCancel,
+  onChange,
+  onDelete,
+  onEdit,
+  onSave,
+  onUndelete
+}) => (
+  <div className={className}>
+    {children ||
         notes.map(note => (
           <Note
             key={note.id ? `js-note-${note.id}` : undefined}
@@ -56,9 +48,8 @@ const Notes: React.FunctionComponent<NotesProps> = ({
           />
         ))
       }
-    </div>
-  );
-};
+  </div>
+);
 
 Notes.propTypes = {
   children: PropTypes.node,


### PR DESCRIPTION
This PR changes the `Notes` component typing so that `onChange`, `onSave`, and `onCancel` are optional. This fix allows us to continue supporting `propTypes` for non TS apps.

If we ever decide to stop supporting `propTypes`, we can improve the typescript interfaces by introducing union types.