### PR TITLE
support localized date formatting in DateInput

### DIFF
--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -16,8 +16,6 @@ import startOfWeek from 'date-fns/start_of_week';
 import enLocale from 'date-fns/locale/en';
 import Table from './Table';
 
-// TODO locale/localize
-
 const Day = ({ day, dateFormat, locale, onClick, ...props }) => {
   const disabled = !day.enabled;
   const classNames = classnames(

--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -13,11 +13,12 @@ import isToday from 'date-fns/is_today';
 import startOfDay from 'date-fns/start_of_day';
 import startOfMonth from 'date-fns/start_of_month';
 import startOfWeek from 'date-fns/start_of_week';
+import enLocale from 'date-fns/locale/en';
 import Table from './Table';
 
 // TODO locale/localize
 
-const Day = ({ day, dateFormat, onClick, ...props }) => {
+const Day = ({ day, dateFormat, locale, onClick, ...props }) => {
   const disabled = !day.enabled;
   const classNames = classnames(
     'text-center',
@@ -29,6 +30,7 @@ const Day = ({ day, dateFormat, onClick, ...props }) => {
   const styles = disabled ? {
     cursor: 'not-allowed'
   } : {};
+  const dayString = format(day.date, dateFormat, { locale });
 
   return (
     // eslint-disable-next-line jsx-a11y/click-events-have-key-events
@@ -40,7 +42,7 @@ const Day = ({ day, dateFormat, onClick, ...props }) => {
       style={styles}
       {...props}
     >
-      {disabled ? <s>{format(day.date, dateFormat)}</s> : format(day.date, dateFormat)}
+      {disabled ? <s>{dayString}</s> : dayString}
       <style jsx>{`
         td:hover {
           font-weight: bold;
@@ -60,6 +62,7 @@ Day.propTypes = {
     visible: PropTypes.bool
   }),
   dateFormat: PropTypes.string,
+  locale: PropTypes.object,
   onClick: PropTypes.func
 };
 
@@ -70,6 +73,7 @@ class Calendar extends React.Component {
     dateFormat: PropTypes.string,
     dateEnabled: PropTypes.func,
     dateVisible: PropTypes.func,
+    locale: PropTypes.object,
     onSelect: PropTypes.func,
     renderDay: PropTypes.func,
     weekDayFormat: PropTypes.string
@@ -81,11 +85,13 @@ class Calendar extends React.Component {
     dateFormat: 'D',
     dateEnabled: () => true,
     dateVisible: () => true,
-    renderDay: (day, dateFormat, onSelect) => (
+    locale: enLocale,
+    renderDay: (day, dateFormat, onSelect, locale) => (
       <Day
         day={day}
         dateFormat={dateFormat}
         key={day.date.toString()}
+        locale={locale}
         onClick={() => day.visible && onSelect(day.date)}
       />
     ),
@@ -125,7 +131,7 @@ class Calendar extends React.Component {
   }
 
   render() {
-    const { date, dateFormat, onSelect, renderDay, weekDayFormat, ...props } = this.props;
+    const { date, dateFormat, locale, onSelect, renderDay, weekDayFormat, ...props } = this.props;
     const weeks = this.visibleWeeks(date);
     delete props.dateEnabled; // Table doesn't need dateVisible
     delete props.dateVisible; // Table doesn't need dateVisible
@@ -147,14 +153,14 @@ class Calendar extends React.Component {
           <col style={{ width: '14.29%' }} />
         </colgroup>
         <thead>
-          <tr>
-            {weeks[0].map((day, i) => <th key={i} className="text-center">{format(day.date, weekDayFormat)}</th>)}
+          <tr className="js-calendar-weekdays">
+            {weeks[0].map((day, i) => <th key={i} className="text-center">{format(day.date, weekDayFormat, { locale })}</th>)}
           </tr>
         </thead>
         <tbody>
           {weeks.map((days, w) => (
             <tr key={w}>
-              {days.map(day => renderDay(day, dateFormat, onSelect))}
+              {days.map(day => renderDay(day, dateFormat, onSelect, locale))}
             </tr>
           ))}
         </tbody>

--- a/src/components/DateInput.js
+++ b/src/components/DateInput.js
@@ -9,6 +9,7 @@ import format from 'date-fns/format';
 import isSameDay from 'date-fns/is_same_day';
 import isValid from 'date-fns/is_valid';
 import startOfToday from 'date-fns/start_of_today';
+import enLocale from 'date-fns/locale/en';
 import Button from './Button';
 import ButtonGroup from './ButtonGroup';
 import Calendar from './Calendar';
@@ -70,6 +71,7 @@ export default class DateInput extends React.Component {
     header: PropTypes.node,
     id: PropTypes.string,
     keyboard: PropTypes.bool,
+    locale: PropTypes.object,
     onBlur: PropTypes.func,
     onChange: PropTypes.func,
     onClose: PropTypes.func,
@@ -91,6 +93,7 @@ export default class DateInput extends React.Component {
     dateVisible: () => true,
     disabled: false,
     keyboard: true,
+    locale: enLocale,
     onBlur: () => {},
     onChange: () => {},
     parse: (value, dateFormat) => parse(value, dateFormat),
@@ -102,7 +105,7 @@ export default class DateInput extends React.Component {
 
     let value = props.defaultValue || '';
     if (props.defaultValue instanceof Date) {
-      value = format(value, props.dateFormat);
+      value = format(value, props.dateFormat, { locale: props.locale });
     }
 
     this.state = {
@@ -164,10 +167,10 @@ export default class DateInput extends React.Component {
 
   setDate = (date, close = false) => {
     const newState = close ? {
-      value: format(date, this.props.dateFormat),
+      value: format(date, this.props.dateFormat, { locale: this.props.locale }),
       open: false
     } : {
-      value: format(date, this.props.dateFormat)
+      value: format(date, this.props.dateFormat, { locale: this.props.locale })
     };
     this.setState(newState, () => {
       this.inputEl.setAttribute('value', newState.value);
@@ -178,7 +181,7 @@ export default class DateInput extends React.Component {
   getCurrentValue = () => {
     if (this.props.value !== undefined) {
       if (this.props.value instanceof Date) {
-        return format(this.props.value, this.props.dateFormat);
+        return format(this.props.value, this.props.dateFormat, { locale: this.props.locale });
       }
       return this.props.value;
     }
@@ -229,7 +232,7 @@ export default class DateInput extends React.Component {
 
     const parsedDate = this.props.parse(this.inputEl.value, this.props.dateFormat);
     if (parsedDate) {
-      const value = format(parsedDate, this.props.dateFormat);
+      const value = format(parsedDate, this.props.dateFormat, { locale: this.props.locale });
       this.inputEl.value = value;
       this.inputEl.setAttribute('value', value);
     }
@@ -316,8 +319,8 @@ export default class DateInput extends React.Component {
                   </Button>
                 </ButtonGroup>
 
-                <span className="m-auto">
-                  {format(date, 'MMMM YYYY')}
+                <span className="js-date-header m-auto">
+                  {format(date, 'MMMM YYYY', { locale: this.props.locale })}
                 </span>
 
                 <ButtonGroup size="sm">

--- a/src/components/DateInput.js
+++ b/src/components/DateInput.js
@@ -262,7 +262,7 @@ export default class DateInput extends React.Component {
 
   render() {
     const { className, dateEnabled, dateVisible, direction, disabled, footer, header, id, showOnFocus,
-      dateFormat, defaultValue, keyboard, onBlur, onChange, parse, positionFixed, value, state, ...props } = this.props; // eslint-disable-line no-shadow
+      dateFormat, defaultValue, keyboard, locale, onBlur, onChange, parse, positionFixed, value, state, ...props } = this.props; // eslint-disable-line no-shadow
     const { open } = this.state;
     const date = this.getCurrentDate();
     const dropdownProps = open ? { positionFixed } : {};
@@ -320,7 +320,7 @@ export default class DateInput extends React.Component {
                 </ButtonGroup>
 
                 <span className="js-date-header m-auto">
-                  {format(date, 'MMMM YYYY', { locale: this.props.locale })}
+                  {format(date, 'MMMM YYYY', { locale })}
                 </span>
 
                 <ButtonGroup size="sm">
@@ -340,6 +340,7 @@ export default class DateInput extends React.Component {
               date={date}
               dateEnabled={dateEnabled}
               dateVisible={dateVisible}
+              locale={locale}
               onSelect={this.onSelect}
               className="m-0"
               style={{ minWidth: '19rem' }}

--- a/test/components/Calendar.spec.js
+++ b/test/components/Calendar.spec.js
@@ -7,6 +7,7 @@ import endOfWeek from 'date-fns/end_of_week';
 import isSameDay from 'date-fns/is_same_day';
 import startOfMonth from 'date-fns/start_of_month';
 import startOfWeek from 'date-fns/start_of_week';
+import frLocale from 'date-fns/locale/fr';
 import { assertAccessible } from '../a11yHelpers';
 import { Calendar } from '../../src';
 
@@ -106,5 +107,31 @@ describe('<Calendar />', () => {
     await assertAccessible(
       <Calendar renderDay={() => <td className="customDay">x</td>} />
     );
+  });
+
+  describe('weeks', () => {
+    it('should render weeks in english by default', () => {
+      const specifiedDate = new Date(2017, 6, 14);
+      const component = mount(<Calendar date={specifiedDate} />);
+      const weekdays = component.find('.js-calendar-weekdays th');
+
+      const names = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'];
+
+      names.forEach((w, i) => {
+        assert.strictEqual(weekdays.at(i).text(), w);
+      });
+    });
+
+    it('should render weeks in provided locale', () => {
+      const specifiedDate = new Date(2017, 6, 14);
+      const component = mount(<Calendar date={specifiedDate} locale={frLocale} />);
+      const weekdays = component.find('.js-calendar-weekdays th');
+
+      const names = ['di', 'lu', 'ma', 'me', 'je', 've', 'sa'];
+
+      names.forEach((w, i) => {
+        assert.strictEqual(weekdays.at(i).text(), w);
+      });
+    });
   });
 });

--- a/test/components/DateInput.spec.js
+++ b/test/components/DateInput.spec.js
@@ -8,6 +8,7 @@ import addYears from 'date-fns/add_years';
 import isSameDay from 'date-fns/is_same_day';
 import isToday from 'date-fns/is_today';
 import startOfToday from 'date-fns/start_of_today';
+import frLocale from 'date-fns/locale/fr';
 import sinon from 'sinon';
 
 import { DateInput } from '../../src';
@@ -318,11 +319,29 @@ describe('<DateInput />', () => {
     });
   });
 
-  it('should render custom header prop', () => {
-    const Custom = () => (<div className='custom-header'>Custom Header</div>);
-    const component = mount(<DateInput header={<Custom />} />);
-    assert.equal(component.find('div.custom-header').length, 1);
-    assert.equal(component.find('header.py-2').length, 0);
+  describe('header', () => {
+    it('should render custom header prop', () => {
+      const Custom = () => (<div className='custom-header'>Custom Header</div>);
+      const component = mount(<DateInput header={<Custom />} />);
+      assert.strictEqual(component.find('div.custom-header').length, 1);
+      assert.strictEqual(component.find('header.py-2').length, 0);
+    });
+
+    it('should render selected month in english by default', () => {
+      const defaultDate = new Date(2017, 6, 14);
+      const component = mount(<DateInput defaultValue={defaultDate} />);
+      const header = component.find('.js-date-header');
+
+      assert.strictEqual(header.text(), 'July 2017');
+    });
+
+    it('should render selected month in provided locale', () => {
+      const defaultDate = new Date(2017, 6, 14);
+      const component = mount(<DateInput defaultValue={defaultDate} locale={frLocale} />);
+      const header = component.find('.js-date-header');
+
+      assert.strictEqual(header.text(), 'juillet 2017');
+    });
   });
 
   it('should render custom footer prop', () => {


### PR DESCRIPTION
This PR adds localization support for `DateInput`. It introduces a new `locale` prop that supports `date-fns` locale objects that will be used to format dates in the component.