### PR TITLE
Currency input replace text mask

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15859,6 +15859,11 @@
       "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
       "dev": true
     },
+    "imask": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/imask/-/imask-6.0.7.tgz",
+      "integrity": "sha512-zyiKRSzuocb2adasVSz0ku9xxejDRs5wME7Dt5Uk1l83HGBFUP7A8y8Z6TytLCtCiS/A1aArlCTqLcOkoVNbNQ=="
+    },
     "immer": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/immer/-/immer-1.10.0.tgz",
@@ -25572,6 +25577,15 @@
       "dev": true,
       "requires": {
         "prop-types": "^15.6.1"
+      }
+    },
+    "react-imask": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/react-imask/-/react-imask-6.0.7.tgz",
+      "integrity": "sha512-2/E8dAiPH4v1AeadEL1xnWG+CfoG4VQYmAGymltWaNBPEDtnCY6H0TKgvRJJOhE+JkYQfjw5KPesrrvNBz0g/A==",
+      "requires": {
+        "imask": "^6.0.7",
+        "prop-types": "^15.7.2"
       }
     },
     "react-input-autosize": {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "memoize-one": "^5.1.1",
     "prop-types": "^15.7.2",
     "react-fontawesome": "^1.7.1",
+    "react-imask": "^6.0.7",
     "react-onclickoutside": "^6.9.0",
     "react-popper": "^1.3.7",
     "react-resize-detector": "^4.2.3",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "date-fns": "^1.30.1",
     "deprecated-prop-type": "^1.0.0",
     "fecha": "^2.3.3",
+    "imask": "^6.0.7",
     "lodash.flow": "^3.5.0",
     "lodash.includes": "^4.3.0",
     "lodash.isequal": "^4.5.0",

--- a/src/components/CurrencyInput.tsx
+++ b/src/components/CurrencyInput.tsx
@@ -1,32 +1,10 @@
 import React, { FunctionComponent } from 'react';
 import classnames from 'classnames';
-import MaskedInput, { MaskedInputProps } from 'react-text-mask';
-import createNumberMask from 'text-mask-addons/dist/createNumberMask';
+import { IMaskInput, IMaskInputProps } from 'react-imask';
 import InputGroup from './InputGroup';
 import InputGroupAddon from './InputGroupAddon';
-
-type Config = {
-  guide?: boolean,
-  previousConformedValue: string,
-  placeholderChar?: string,
-  placeholder?: string,
-  currentCaretPosition?: number,
-  keepCharPositions?: boolean,
-  rawValue: string,
-}
-
-/**
- * In the case where the user enters an extra "." at the end of the input the default behavior will
- * be to remove the original decimal point and keep the new one, resulting in the value being
- * multiplied by 100.  If we detect an additional decimal point we can ignore the extra character.
- */
-function preventMultipleDecimalPoint(conformedValue: string, config: Config): string {
-  let result = conformedValue;
-  if (config.rawValue.match(/\..*\./)) {
-    result = config.previousConformedValue;
-  }
-  return result;
-}
+// eslint-disable-next-line import/no-unresolved
+import './TypeHelpers/react-imask.d.ts';
 
 type Props = {
   allowDecimal?: boolean;
@@ -34,17 +12,18 @@ type Props = {
   className?: string;
   id?: string;
   includeThousandsSeparator?: boolean;
-  inputProps?: MaskedInputProps;
+  inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
+  padZeros?: boolean,
   size?: string;
-  state?: any;
-  type?: any;
-} & MaskedInputProps;
+  value?: string | number;
+} & React.InputHTMLAttributes<HTMLInputElement>;
 
 const defaultProps = {
   allowDecimal: true,
   allowNegative: false,
   includeThousandsSeparator: true,
-}
+  padZeros: true,
+};
 
 // TODO support I18n
 const CurrencyInput: FunctionComponent<Props> = ({
@@ -53,9 +32,10 @@ const CurrencyInput: FunctionComponent<Props> = ({
   className,
   includeThousandsSeparator = defaultProps.includeThousandsSeparator,
   inputProps,
+  padZeros = defaultProps.padZeros,
   size,
-  state,
-  type,
+  value,
+  onChange: onAccept,
   ...props
 }: Props) => {
   const inputClassNames = classnames('form-control', inputProps && inputProps.className);
@@ -64,23 +44,20 @@ const CurrencyInput: FunctionComponent<Props> = ({
     ...inputProps,
     ...props,
     className: inputClassNames,
-    // There is a weird bug in the MaskedInput where if the "value" prop gets set to null the
-    // input value gets set to "_".  Setting guide to false instead of undefined solves the
-    // problem.
-    guide: false,
-    mask: createNumberMask({
-      allowDecimal,
-      allowNegative,
-      includeThousandsSeparator,
-      prefix: ''
-    }),
-    pipe: preventMultipleDecimalPoint
+    mask: Number,
+    onAccept,
+    padFractionalZeros: allowDecimal && padZeros,
+    radix: '.',
+    scale: allowDecimal ? 2 : 0,
+    signed: allowNegative,
+    thousandsSeparator: includeThousandsSeparator ? ',' : '',
+    value: value?.toString(),
   };
 
   return (
     <InputGroup size={size} className={className}>
       <InputGroupAddon addonType="prepend">$</InputGroupAddon>
-      <MaskedInput {...maskedProps} />
+      <IMaskInput {...maskedProps} />
     </InputGroup>
   );
 };

--- a/src/components/CurrencyInput.tsx
+++ b/src/components/CurrencyInput.tsx
@@ -4,8 +4,6 @@ import { IMaskInput, IMaskInputProps } from 'react-imask';
 import IMask from 'imask';
 import InputGroup from './InputGroup';
 import InputGroupAddon from './InputGroupAddon';
-// eslint-disable-next-line import/no-unresolved
-import './TypeHelpers/react-imask.d.ts';
 
 type InputProps = Omit<React.InputHTMLAttributes<HTMLInputElement>, | 'max' | 'min' >;
 

--- a/src/components/CurrencyInput.tsx
+++ b/src/components/CurrencyInput.tsx
@@ -1,6 +1,7 @@
 import React, { FunctionComponent } from 'react';
 import classnames from 'classnames';
 import { IMaskInput, IMaskInputProps } from 'react-imask';
+import IMask from 'imask';
 import InputGroup from './InputGroup';
 import InputGroupAddon from './InputGroupAddon';
 // eslint-disable-next-line import/no-unresolved
@@ -18,7 +19,6 @@ type Props = {
   padZeros?: boolean,
   size?: string;
   value?: string | number;
-  onChange?: (value: string, masked: string) => void,
 } & InputProps;
 
 const defaultProps = {
@@ -38,12 +38,20 @@ const CurrencyInput: FunctionComponent<Props> = ({
   padZeros = defaultProps.padZeros,
   size,
   value,
-  onChange: onAccept,
+  onChange,
   ...props
 }: Props) => {
   const inputClassNames = classnames('form-control', inputProps && inputProps.className);
+  const onAccept = (val: string, mask: IMask.InputMask<IMask.MaskedNumberOptions>) => {
+    if (onChange) {
+      const ev = new Event('change') as unknown as React.ChangeEvent<HTMLInputElement>;
+      // @ts-ignore
+      mask.el.input.dispatchEvent(ev);
+      onChange(ev);
+    }
+  };
 
-  const maskedProps = {
+  const maskedProps: IMaskInputProps<IMask.MaskedNumberOptions> = {
     ...inputProps,
     ...props,
     className: inputClassNames,

--- a/src/components/CurrencyInput.tsx
+++ b/src/components/CurrencyInput.tsx
@@ -6,17 +6,20 @@ import InputGroupAddon from './InputGroupAddon';
 // eslint-disable-next-line import/no-unresolved
 import './TypeHelpers/react-imask.d.ts';
 
+type InputProps = Omit<React.InputHTMLAttributes<HTMLInputElement>, | 'max' | 'min' >;
+
 type Props = {
   allowDecimal?: boolean;
   allowNegative?: boolean;
   className?: string;
   id?: string;
   includeThousandsSeparator?: boolean;
-  inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
+  inputProps?: InputProps;
   padZeros?: boolean,
   size?: string;
   value?: string | number;
-} & React.InputHTMLAttributes<HTMLInputElement>;
+  onChange?: (value: string, masked: string) => void,
+} & InputProps;
 
 const defaultProps = {
   allowDecimal: true,

--- a/src/components/TypeHelpers/react-imask.d.ts
+++ b/src/components/TypeHelpers/react-imask.d.ts
@@ -10,9 +10,9 @@ declare module 'react-imask' {
     validate?: (value: string, masked: string) => void,
     commit?: (value: string, masked: string) => void,
     overwrite?: boolean,
-    onAccept?: <T>(...args: T[]) => void;
-    onComplete?: <T>(...args: T[]) => void;
-  };
+    onAccept?: (value: string, masked: string) => void;
+    onComplete?: (value: string, masked: string) => void;
+  } & React.InputHTMLAttributes<HTMLInputElement>;
 
   export function IMaskMixin<T, D>(
     Component: React.ComponentType<{ inputRef: React.Ref<D> } & T>

--- a/src/components/TypeHelpers/react-imask.d.ts
+++ b/src/components/TypeHelpers/react-imask.d.ts
@@ -1,22 +1,21 @@
 declare module 'react-imask' {
-  import Imask from 'imask';
+  import IMask from 'imask';
 
   // https://github.com/uNmAnNeR/imaskjs/blob/master/packages/react-imask/src/mixin.js
-
-  export type IMaskInputProps = Imask.AnyMaskedOptions & {
+  export type IMaskInputProps<MaskOptions extends IMask.AnyMaskedOptions> = MaskOptions & {
     unmask?: boolean;
     value?: any,
     prepare?: (value: string) => string,
-    validate?: (value: string, masked: string) => void,
-    commit?: (value: string, masked: string) => void,
+    validate?: (value: string, masked: IMask.Masked<MaskOptions['mask']>) => void,
+    commit?: (value: string, masked: IMask.Masked<MaskOptions['mask']>) => void,
     overwrite?: boolean,
-    onAccept?: (value: string, masked: string) => void;
-    onComplete?: (value: string, masked: string) => void;
+    onAccept?: (value: string, mask: IMask.InputMask<MaskOptions>) => void;
+    onComplete?: (value: string, mask: IMask.InputMask<MaskOptions>) => void;
   } & React.InputHTMLAttributes<HTMLInputElement>;
 
-  export function IMaskMixin<T, D>(
-    Component: React.ComponentType<{ inputRef: React.Ref<D> } & T>
-  ): React.ComponentType<T & IMaskInputProps>;
+  export function IMaskMixin<T, TProps, MaskOptions extends IMask.AnyMaskedOptions>(
+    Component: React.ComponentType<{ inputRef: React.Ref<T> } & TProps>
+  ): React.ComponentType<TProps & IMaskInputProps<MaskOptions>>;
 
-  export const IMaskInput: React.ComponentType<IMaskInputProps>;
+  export function IMaskInput<MaskOptions extends IMask.AnyMaskedOptions>(props: IMaskInputProps<MaskOptions>): JSX.Element;
 }

--- a/src/components/TypeHelpers/react-imask.d.ts
+++ b/src/components/TypeHelpers/react-imask.d.ts
@@ -1,0 +1,22 @@
+declare module 'react-imask' {
+  import Imask from 'imask';
+
+  // https://github.com/uNmAnNeR/imaskjs/blob/master/packages/react-imask/src/mixin.js
+
+  export type IMaskInputProps = Imask.AnyMaskedOptions & {
+    unmask?: boolean;
+    value?: any,
+    prepare?: (value: string) => string,
+    validate?: (value: string, masked: string) => void,
+    commit?: (value: string, masked: string) => void,
+    overwrite?: boolean,
+    onAccept?: <T>(...args: T[]) => void;
+    onComplete?: <T>(...args: T[]) => void;
+  };
+
+  export function IMaskMixin<T, D>(
+    Component: React.ComponentType<{ inputRef: React.Ref<D> } & T>
+  ): React.ComponentType<T & IMaskInputProps>;
+
+  export const IMaskInput: React.ComponentType<IMaskInputProps>;
+}

--- a/stories/CurrencyInput.stories.js
+++ b/stories/CurrencyInput.stories.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { action } from '@storybook/addon-actions';
+import { boolean } from '@storybook/addon-knobs';
 import { CurrencyInput } from '../src';
 
 export default {
@@ -7,20 +8,14 @@ export default {
   component: CurrencyInput,
 };
 
-export const DefaultProps = () => (
-  <CurrencyInput onChange={action('onChange')} />
-);
-
-export const AllowNegative = () => (
-  <CurrencyInput allowNegative onChange={action('onChange')} />
-);
-
-export const DisallowDecimals = () => (
-  <CurrencyInput allowDecimal={false} onChange={action('onChange')} />
-);
-
-export const DisallowCommas = () => (
-  <CurrencyInput includeThousandsSeparator={false} onChange={action('onChange')} />
+export const Example = () => (
+  <CurrencyInput
+    onChange={action('onChange')}
+    allowDecimal={boolean('allowDecimal', true)}
+    allowNegative={boolean('allowNegative', true)}
+    includeThousandsSeparator={boolean('includeThousandsSeparator', true)}
+    padZeros={boolean('padZeros', true)}
+  />
 );
 
 export const RightAligned = () => (

--- a/test/components/CurrencyInput.spec.js
+++ b/test/components/CurrencyInput.spec.js
@@ -84,8 +84,7 @@ describe('<CurrencyInput />', () => {
       assert.strictEqual(input.getDOMNode().value, '0.00');
     });
 
-    // TODO skipped pending this issue/question: https://github.com/text-mask/text-mask/issues/372
-    it.skip('should zero pad 1 decimal', () => {
+    it('should zero pad 1 decimal', () => {
       const component = mount(<CurrencyInput onChange={callback} value={1234.5} />);
       const input = component.find('input');
 

--- a/test/components/CurrencyInput.spec.js
+++ b/test/components/CurrencyInput.spec.js
@@ -32,7 +32,7 @@ describe('<CurrencyInput />', () => {
     it('can be disabled', () => {
       const component = mount(<CurrencyInput value="123,456" includeThousandsSeparator={false} />);
       const input = component.find('input');
-      assert.equal(input.getDOMNode().value, '123456');
+      assert.equal(input.getDOMNode().value, '123456.00');
     });
   });
 
@@ -40,13 +40,13 @@ describe('<CurrencyInput />', () => {
     it('should be disabled by default', () => {
       const component = mount(<CurrencyInput value="-123" />);
       const input = component.find('input');
-      assert.equal(input.getDOMNode().value, '123');
+      assert.equal(input.getDOMNode().value, '123.00');
     });
 
     it('can be enabled', () => {
       const component = mount(<CurrencyInput value="-123" allowNegative />);
       const input = component.find('input');
-      assert.equal(input.getDOMNode().value, '-123');
+      assert.equal(input.getDOMNode().value, '-123.00');
     });
   });
 
@@ -71,20 +71,17 @@ describe('<CurrencyInput />', () => {
     });
 
     it('should ignore additional decimal points', () => {
-      const component = mount(<CurrencyInput value={1234.56} />);
+      const component = mount(<CurrencyInput value="1234.56." />);
       const input = component.find('input');
-      input.getDOMNode().value = '1,234.56.';
-      input.simulate('input');
-      assert.equal(input.getDOMNode().value, '1,234.56');
+
+      assert.strictEqual(input.getDOMNode().value, '1,234.56');
     });
 
     it('should prefix decimal only currency with 0', () => {
-      const component = mount(<CurrencyInput onChange={callback} />);
+      const component = mount(<CurrencyInput onChange={callback} value="." />);
       const input = component.find('input');
 
-      input.getDOMNode().value = '.';
-      input.simulate('input');
-      assert.equal(input.getDOMNode().value, '0.');
+      assert.strictEqual(input.getDOMNode().value, '0.00');
     });
 
     // TODO skipped pending this issue/question: https://github.com/text-mask/text-mask/issues/372


### PR DESCRIPTION
This PR migrates CurrencyInput to use react-imask instead of react-text-mask (which is no longer being maintained). It adds a new `padZeros` property that defaults to true. No breaking changes.

Will follow up with a second PR to update `MaskedInput`, but that will be a breaking change, so we're going to bundle it with the next major version update.