### PR TITLE
Change Select border styling to match Coastline input styling

### DIFF
--- a/src/components/SelectArrow.js
+++ b/src/components/SelectArrow.js
@@ -52,7 +52,6 @@ const SelectArrow = ({ isOpen, render }) => (
           border-bottom-right-radius: 0;
           border-bottom-left-radius: 0;
           background: #fff;
-          border-color: silver #d9d9d9 #e6e6e6;
         }
         .Select.is-open > .Select-control .Select-arrow {
           top: -2px;
@@ -138,9 +137,8 @@ const SelectArrow = ({ isOpen, render }) => (
         }
         .Select-control {
           background-color: #fff;
-          border-color: #e6e6e6 #d9d9d9 silver;
-          border-radius: 4px;
-          border: 1px solid #d9d9d9;
+          border-radius: 0.15rem;
+          border: 1px solid #a9b7c1;
           color: #333;
           cursor: default;
           display: table;


### PR DESCRIPTION
**Note:** I did not attempt to incorporate the Coastline stylesheet in any way. This is a quick fix to update the styling closer to current Coastline styling.

.Select-control: We remove `border-color` since it is already applied in
the `border` property.

.Select.is-open > .Select-control: We remove `border-color` to match the
normal Input styling, which doesn't change when it is open.

Updated `Select`:
![image](https://user-images.githubusercontent.com/13406078/116325144-550fa400-a776-11eb-87ce-e9dc7a2ff16f.png)

Existing `Input type='select':
![image](https://user-images.githubusercontent.com/13406078/116325187-6789dd80-a776-11eb-9d1a-784d417b870c.png)
