### PR TITLE
Add create-able options for Combobox

### DIFF
--- a/src/components/Combobox.tsx
+++ b/src/components/Combobox.tsx
@@ -231,7 +231,7 @@ function Combobox<T>({
             createOption();
           }}
         >
-          {`Add option: ${inputValue}`}
+          {`Create "${inputValue}"`}
         </DropdownItem>
       );
     }

--- a/src/components/Combobox.tsx
+++ b/src/components/Combobox.tsx
@@ -156,7 +156,7 @@ function Combobox<T>({
     if (!onCreate) return;
 
     const optionValue = onCreate(inputValue);
-    selectOption(optionValue);
+    if (optionValue) selectOption(optionValue);
   };
 
   const handleOptionsKeyboardNav = ({ key }: React.KeyboardEvent<HTMLElement>) => {

--- a/src/components/Combobox.tsx
+++ b/src/components/Combobox.tsx
@@ -32,6 +32,7 @@ interface ComboboxProps<T> extends Omit<InputProps, 'onChange'> {
   noResultsLabel?: string;
   onChange?: (value?: T | T[]) => void;
   onCreate?: (str: string) => T;
+  isValidNewOption?: (label: string) => boolean;
   filterOptions?: (options: Option<T>[], value: string) => Option<T>[];
   renderInputValue?: (option: Option<T>) => string;
   renderOption?: (option: Option<T>) => React.ReactNode;
@@ -43,6 +44,7 @@ const defaultProps = {
   noResultsLabel: 'No results found',
   onChange: () => {},
   filterOptions: (o: Option<any>[], v: any) => o.filter(option => v ? option.label.toLowerCase().indexOf(v.toLowerCase()) > -1 : true),
+  isValidNewOption: () => true,
   renderInputValue: (option: Option<any>) => option.label,
   renderOption: (option: Option<any>) => option.label,
 };
@@ -52,6 +54,7 @@ function Combobox<T>({
   noResultsLabel = defaultProps.noResultsLabel,
   onChange = defaultProps.onChange,
   onCreate,
+  isValidNewOption = defaultProps.isValidNewOption,
   filterOptions = defaultProps.filterOptions,
   renderInputValue = defaultProps.renderInputValue,
   renderOption = defaultProps.renderOption,
@@ -225,6 +228,8 @@ function Combobox<T>({
       return (
         <DropdownItem
           active={noMatches}
+          data-testid="create-new-option"
+          disabled={!isValidNewOption(inputValue)}
           onMouseDown={(ev) => {
             ev.preventDefault();
             ev.stopPropagation();

--- a/stories/Combobox.stories.js
+++ b/stories/Combobox.stories.js
@@ -122,6 +122,32 @@ export const Grouped = () => {
   );
 };
 
+export const CreatableOptions = () => {
+  const [value, setValue] = useState();
+  const [opts, setOpts] = useState(options);
+
+  const onCreate = (str) => {
+    const newOpt = { value: str, label: str };
+    setOpts([...opts, newOpt]);
+
+    return newOpt.value;
+  };
+
+  return (
+    <Combobox
+      direction={select('direction', ['', 'down', 'up'], '')}
+      onChange={setValue}
+      onCreate={onCreate}
+      options={opts}
+      value={value}
+      disabled={boolean('disabled', Combobox.defaultProps.disabled)}
+      noResultsLabel={text('noResultsLabel', Combobox.defaultProps.noResultsLabel)}
+      placeholder={text('placeholder', Combobox.defaultProps.placeholder)}
+      inputClassName={text('inputClassName', '')}
+    />
+  );
+};
+
 export const CustomOptions = () => {
   const [value, setValue] = useState();
   const mixedOptions = [

--- a/test/components/Combobox.spec.js
+++ b/test/components/Combobox.spec.js
@@ -261,6 +261,24 @@ describe('<Combobox />', () => {
     });
   });
 
+  it('should support creating options', () => {
+    const mockOnChange = sinon.spy();
+
+    const onCreateObj = { onCreate: s => s };
+    const mockOnCreate = sinon.spy(onCreateObj, 'onCreate');
+
+    const combobox = render(<Combobox options={OPTIONS} onChange={mockOnChange} onCreate={mockOnCreate} />);
+
+    const input = combobox.getByTestId('combobox-input');
+    fireEvent.focus(input);
+
+    fireEvent.change(input, { target: { value: 'new option' } });
+    fireEvent.keyDown(input, { key: 'Enter', code: 13 });
+
+    sinon.assert.calledWith(mockOnCreate, 'new option');
+    sinon.assert.calledWith(mockOnChange, 'new option');
+  });
+
   describe('multiselect', () => {
     it('should render multiple values as buttons to remove the option', () => {
       const combobox = render(<Combobox options={OPTIONS} value={[1, 2]} multi />);

--- a/test/components/Combobox.spec.js
+++ b/test/components/Combobox.spec.js
@@ -261,22 +261,48 @@ describe('<Combobox />', () => {
     });
   });
 
-  it('should support creating options', () => {
-    const mockOnChange = sinon.spy();
+  describe('creatable options', () => {
+    it('should support creating options', () => {
+      const mockOnChange = sinon.spy();
 
-    const onCreateObj = { onCreate: s => s };
-    const mockOnCreate = sinon.spy(onCreateObj, 'onCreate');
+      const onCreateObj = { onCreate: s => s };
+      const mockOnCreate = sinon.spy(onCreateObj, 'onCreate');
 
-    const combobox = render(<Combobox options={OPTIONS} onChange={mockOnChange} onCreate={mockOnCreate} />);
+      const combobox = render(<Combobox options={OPTIONS} onChange={mockOnChange} onCreate={mockOnCreate} />);
 
-    const input = combobox.getByTestId('combobox-input');
-    fireEvent.focus(input);
+      const input = combobox.getByTestId('combobox-input');
+      fireEvent.focus(input);
 
-    fireEvent.change(input, { target: { value: 'new option' } });
-    fireEvent.keyDown(input, { key: 'Enter', code: 13 });
+      fireEvent.change(input, { target: { value: 'new option' } });
+      fireEvent.keyDown(input, { key: 'Enter', code: 13 });
 
-    sinon.assert.calledWith(mockOnCreate, 'new option');
-    sinon.assert.calledWith(mockOnChange, 'new option');
+      sinon.assert.calledWith(mockOnCreate, 'new option');
+      sinon.assert.calledWith(mockOnChange, 'new option');
+    });
+
+    it('should validate creatable options', () => {
+      const mockOnChange = sinon.spy();
+
+      const onCreateObj = { onCreate: s => s };
+      const mockOnCreate = sinon.spy(onCreateObj, 'onCreate');
+
+      const combobox = render(<Combobox options={OPTIONS} onChange={mockOnChange} onCreate={mockOnCreate} isValidNewOption={s => s === 'foobar'} />);
+
+      const input = combobox.getByTestId('combobox-input');
+      fireEvent.focus(input);
+
+      fireEvent.change(input, { target: { value: 'new option' } });
+
+      let newOptionButton = combobox.getByTestId('create-new-option');
+
+      assert(newOptionButton.hasAttribute('disabled'));
+
+      fireEvent.change(input, { target: { value: 'foobar' } });
+
+      newOptionButton = combobox.getByTestId('create-new-option');
+
+      assert(!newOptionButton.hasAttribute('disabled'));
+    });
   });
 
   describe('multiselect', () => {


### PR DESCRIPTION
Add create-able options for Combobox.

The creatable options of combobox differ from the `Select` in that options are completely controlled. Instead of having `creatable` and `onNewOptionClick` props. We simplified it to an `onCreate` prop that's required if you want to enable creatable options.

`onCreate` should return the value for the newly created option or a falsey value if creation failed (i.e. failed validation).
`isValidNewOption` takes in a string (input value) and returns a boolean