### PR TITLE
Combobox - preserve default focus behavior for caret button

### DIFF
--- a/src/components/Combobox.tsx
+++ b/src/components/Combobox.tsx
@@ -319,12 +319,10 @@ function Combobox<T>({
                 disabled={disabled}
                 active={open}
                 onMouseDown={(ev) => {
-                  ev.preventDefault();
                   ev.stopPropagation();
                   setOpen(!open);
                 }}
                 type="button"
-                tabIndex={-1}
                 aria-label="Toggle options menu"
               >
                 <Icon name={open ? 'caret-up' : 'caret-down'} fixedWidth />

--- a/test/components/Combobox.spec.js
+++ b/test/components/Combobox.spec.js
@@ -80,6 +80,19 @@ describe('<Combobox />', () => {
     assert.equal(combobox.getByTestId('combobox-menu').getAttribute('aria-hidden'), 'true');
   });
 
+  it('should close menu on blur of caret button', () => {
+    const combobox = render(<Combobox options={OPTIONS} />);
+
+    const caret = combobox.getByTestId('combobox-caret');
+    fireEvent.mouseDown(caret);
+
+    assert.strictEqual(combobox.getByTestId('combobox-menu').getAttribute('aria-hidden'), 'false');
+
+    fireEvent.blur(caret);
+
+    assert.strictEqual(combobox.getByTestId('combobox-menu').getAttribute('aria-hidden'), 'true');
+  });
+
   it('should blur input on close', () => {
     const combobox = render(<Combobox options={OPTIONS} />);
     const input = combobox.getByTestId('combobox-input');


### PR DESCRIPTION
This PR will preserve menu close behavior when clicking away from the combobox if the menu was opened using the caret button.