### PR TITLE
feat: set fade to false for feature banner

### DIFF
--- a/src/components/FeatureBanner.js
+++ b/src/components/FeatureBanner.js
@@ -21,7 +21,7 @@ export default class FeatureBanner extends React.Component {
     const alertStyle = 'font-weight-bold text-uppercase';
 
     return (
-      <Alert color={color} className="align-items-center d-flex p-0">
+      <Alert color={color} className="align-items-center d-flex p-0" fade={false}>
         {alertText ?
           <h2 className={`${alertStyle} text-center m-0 px-3 d-none d-sm-block`}>
             {alertText}


### PR DESCRIPTION
The fade property on the Reactstrap Alert component causes the alert
to fade in when it is rendered. This may make for a slightly smoother
experience when an alert pops up due to an error submitting a form, for
example. However, it is not as nice of an experience for static
components which are always rendered on the page, such as the feature
banner, since it causes them to take longer to render. It also causes
jarring behavior when swapping out some elements in the page while
leaving the feature banner unchanged.

## Before

https://user-images.githubusercontent.com/16616853/118706771-996aee80-b7ce-11eb-9133-5b573382c50d.mov

## After

https://user-images.githubusercontent.com/16616853/118706744-92dc7700-b7ce-11eb-9f66-332bf9baf59d.mov