### PR TITLE
Support default `type` prop for `Status` component

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,9 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        # TODO: switch back to 16.x when this issue is resolved with 16.9
+        # https://github.com/nodejs/node/issues/40030
+        node-version: [12.x, 14.x, 16.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/src/components/Status.tsx
+++ b/src/components/Status.tsx
@@ -4,12 +4,12 @@ import Icon from './Icon';
 import { FontAwesomeAPMProps } from './icon/FontAwesomeAPM';
 
 interface StatusProps extends Omit<FontAwesomeAPMProps, 'name'> {
-  type: 'info' | 'muted' | 'success' | 'danger' | 'warning';
+  type?: 'info' | 'muted' | 'success' | 'danger' | 'warning' | 'none';
   className?: string;
 }
 
-const Status = ({ type, className, ...props }: StatusProps) => {
-  let name = 'circle';
+const Status = ({ type = 'none', className, ...props }: StatusProps) => {
+  let name = '';
   switch (type) {
     case 'info':
       name = 'info-circle';
@@ -26,10 +26,14 @@ const Status = ({ type, className, ...props }: StatusProps) => {
     case 'warning':
       name = 'exclamation-circle';
       break;
+    case 'none':
+      name = 'circle';
+      break;
     default:
+      throw new Error(`Unsupported value for 'type' prop passed to Status component: "${type}"`);
   }
   return (
-    <Icon {...props} name={name} fixedWidth className={classnames(`text-${type || 'muted'}`, className)} />
+    <Icon {...props} name={name} fixedWidth className={classnames(`text-${type === 'none' ? 'muted' : type}`, className)} />
   );
 };
 

--- a/test/components/Status.spec.tsx
+++ b/test/components/Status.spec.tsx
@@ -16,19 +16,9 @@ describe('<Status />', () => {
     assert.strictEqual(icon.prop('className'), 'text-info');
   });
 
-  it('should take a type option', () => {
+  it('should take a type option and classnames', () => {
     const icon = shallow(<Status type='muted' className='mx-5' />).find(Icon);
     assert.strictEqual(icon.prop('className'), 'text-muted mx-5');
-  });
-
-  it('shouldnt let a name prop override type', () => {
-    const icon = shallow(<Status type='success' name='warning' />).find(Icon);
-    assert.strictEqual(icon.prop('name'), 'check-circle');
-  });
-
-  it('shouldnt let a name prop override type', () => {
-    const icon = shallow(<Status type='success' name='warning' />).find(Icon);
-    assert.strictEqual(icon.prop('name'), 'check-circle');
   });
 
   it('should take custom icon props', () => {

--- a/test/components/Status.spec.tsx
+++ b/test/components/Status.spec.tsx
@@ -16,6 +16,18 @@ describe('<Status />', () => {
     assert.strictEqual(icon.prop('className'), 'text-info');
   });
 
+  it('should accept none as an option', () => {
+    const icon = shallow(<Status type='none' />).find(Icon);
+    assert.strictEqual(icon.prop('name'), 'circle');
+    assert.strictEqual(icon.prop('className'), 'text-muted');
+  });
+
+  it('should default to the "none" type', () => {
+    const icon = shallow(<Status />).find(Icon);
+    assert.strictEqual(icon.prop('name'), 'circle');
+    assert.strictEqual(icon.prop('className'), 'text-muted');
+  });
+
   it('should take a type option and classnames', () => {
     const icon = shallow(<Status type='muted' className='mx-5' />).find(Icon);
     assert.strictEqual(icon.prop('className'), 'text-muted mx-5');


### PR DESCRIPTION
The `Status` component already implicitly supports not specifying the type prop, e.g. `<Status />`.

In typescript, however, this causes an error because the `type` prop is not marked as optional.

This PR supports omitting the prop value in TS as well as an explicit value for this state.