### PR TITLE
Prevent Enter from submitting Forms

### DIFF
--- a/src/components/Combobox.tsx
+++ b/src/components/Combobox.tsx
@@ -182,10 +182,11 @@ function Combobox<T>({
     if (optionValue) selectOption(optionValue);
   };
 
-  const handleOptionsKeyboardNav = ({ key }: React.KeyboardEvent<HTMLElement>) => {
+  const handleOptionsKeyboardNav = (e : React.KeyboardEvent<HTMLElement>) => {
     const input = inputElement?.current;
     const allSelected = input?.selectionStart === 0 && input.selectionEnd === input.value.length;
     const isDisplayingSelected = !multi && selected && inputValue === (selected as Option<T>).label;
+    const key = e.key;
 
     if (!open && key === 'ArrowDown') {
       setOpen(true);
@@ -196,6 +197,7 @@ function Combobox<T>({
       }
 
       selectOption(visibleOptions[focusedOptionIndex].value);
+      e.preventDefault();
     } else if (key === 'ArrowDown' && focusedOptionIndex < visibleOptions.length - 1) {
       setFocusedOptionIndex(focusedOptionIndex + 1);
     } else if (key === 'ArrowUp' && focusedOptionIndex > 0) {


### PR DESCRIPTION
If Combobox is used within a `form` element and there
is a `button` of type `submit` in the `form`, whenever a 
user selects a value using the `Enter` key, the value is 
selected, then the `form` is automatically submitted.

This can be undesirable, especially if this is the first input
of the form and a user uses `Enter` to select a value.

In order to prevent this, we add a `preventDefault` call to the
`Enter` key section of the `onKeyDown` prop function. This will
prevent users from prematurely submitting forms while selecting
values in Combobox.