### PR TITLE
Add prop to control col widths

### DIFF
--- a/src/components/AddressInput.d.ts
+++ b/src/components/AddressInput.d.ts
@@ -11,6 +11,14 @@ interface AddressInterface {
 
 type AddressNames = keyof AddressInterface;
 
+interface ColWidthInterface {
+  xs?: number;
+  sm?: number;
+  md?: number;
+  lg?: number;
+  xl?: number;
+}
+
 interface AddressInputProps {
   className?: string;
   defaultValue?: AddressInterface;
@@ -23,6 +31,11 @@ interface AddressInputProps {
   showCountry?: boolean;
   showLabels?: boolean;
   value?: AddressInterface;
+  width?: {
+    city: ColWidthInterface;
+    state: ColWidthInterface;
+    postal: ColWidthInterface;
+  };
 }
 
 declare class AddressInput extends React.Component<AddressInputProps, {}> { }

--- a/src/components/AddressInput.d.ts
+++ b/src/components/AddressInput.d.ts
@@ -21,6 +21,7 @@ interface ColWidthInterface {
 
 interface AddressInputProps {
   className?: string;
+  cityColClassName?: string;
   defaultValue?: AddressInterface;
   disabled?: boolean;
   error?: AddressInterface;
@@ -30,6 +31,7 @@ interface AddressInputProps {
   onChange?: (inputName: AddressNames) => void;
   showCountry?: boolean;
   showLabels?: boolean;
+  stateColClassName?: string;
   value?: AddressInterface;
   width?: {
     city: ColWidthInterface;

--- a/src/components/AddressInput.js
+++ b/src/components/AddressInput.js
@@ -32,6 +32,7 @@ const colWidthPropType = {
 class AddressInput extends React.Component {
   static propTypes = {
     className: PropTypes.string,
+    cityColClassName: PropTypes.string,
     countries: PropTypes.arrayOf(PropTypes.string),
     defaultValue: PropTypes.object,
     inputName: PropTypes.shape(addressPropType),
@@ -44,6 +45,7 @@ class AddressInput extends React.Component {
     onChange: PropTypes.func,
     showCountry: PropTypes.bool,
     showLabels: PropTypes.bool,
+    stateColClassName: PropTypes.string,
     value: PropTypes.object,
     width: PropTypes.shape({
       city: colWidthPropType,
@@ -54,6 +56,7 @@ class AddressInput extends React.Component {
 
   static defaultProps = {
     className: '',
+    cityColClassName: 'pr-sm-3',
     defaultValue: {},
     disabled: false,
     error: {},
@@ -78,6 +81,7 @@ class AddressInput extends React.Component {
     onChange: () => {},
     showCountry: true,
     showLabels: false,
+    stateColClassName: 'pr-3',
     value: {},
     width: {
       city: { xs: 12, sm: 6 },
@@ -104,7 +108,7 @@ class AddressInput extends React.Component {
   }
 
   render() {
-    const { className, countries, disabled, error, hints, id, labels, onBlur, showCountry, showLabels, inputName, width } = this.props;
+    const { className, cityColClassName, countries, disabled, error, hints, id, inputName, labels, onBlur, showCountry, showLabels, stateColClassName, width } = this.props;
 
     const inputId = id || 'addressInput';
     const address1Id = `${inputId}_address1`;
@@ -161,7 +165,7 @@ class AddressInput extends React.Component {
           />
         </FormLabelGroup>
         <Row className="no-gutters">
-          <Col {...width.city} className="js-city-col pr-sm-3">
+          <Col {...width.city} className={`js-city-col ${cityColClassName}`}>
             <FormLabelGroup
               rowClassName={classnames({ 'mb-sm-0': !showCountry })}
               feedback={error.city}
@@ -185,7 +189,7 @@ class AddressInput extends React.Component {
               />
             </FormLabelGroup>
           </Col>
-          <Col {...width.state} className="js-state-col pr-3">
+          <Col {...width.state} className={`js-state-col ${stateColClassName}`}>
             <FormLabelGroup
               rowClassName={classnames({ 'mb-0': !showCountry })}
               feedback={error.state}

--- a/src/components/AddressInput.js
+++ b/src/components/AddressInput.js
@@ -21,6 +21,14 @@ export const addressPropType = {
   countryCode: PropTypes.string,
 };
 
+const colWidthPropType = {
+  xs: PropTypes.number,
+  sm: PropTypes.number,
+  md: PropTypes.number,
+  lg: PropTypes.number,
+  xl: PropTypes.number,
+};
+
 class AddressInput extends React.Component {
   static propTypes = {
     className: PropTypes.string,
@@ -37,6 +45,11 @@ class AddressInput extends React.Component {
     showCountry: PropTypes.bool,
     showLabels: PropTypes.bool,
     value: PropTypes.object,
+    width: PropTypes.shape({
+      city: colWidthPropType,
+      state: colWidthPropType,
+      postal: colWidthPropType,
+    }).isRequired,
   };
 
   static defaultProps = {
@@ -66,6 +79,11 @@ class AddressInput extends React.Component {
     showCountry: true,
     showLabels: false,
     value: {},
+    width: {
+      city: { xs: 12, sm: 6 },
+      state: { xs: 4, sm: 3, md: 2 },
+      postal: { xs: 8, sm: 3, md: 4 },
+    },
   };
 
   onChange = (update) => {
@@ -86,7 +104,7 @@ class AddressInput extends React.Component {
   }
 
   render() {
-    const { className, countries, disabled, error, hints, id, labels, onBlur, showCountry, showLabels, inputName } = this.props;
+    const { className, countries, disabled, error, hints, id, labels, onBlur, showCountry, showLabels, inputName, width } = this.props;
 
     const inputId = id || 'addressInput';
     const address1Id = `${inputId}_address1`;
@@ -143,7 +161,7 @@ class AddressInput extends React.Component {
           />
         </FormLabelGroup>
         <Row className="no-gutters">
-          <Col sm={6} xs={12} className="pr-sm-3">
+          <Col {...width.city} className="js-city-col pr-sm-3">
             <FormLabelGroup
               rowClassName={classnames({ 'mb-sm-0': !showCountry })}
               feedback={error.city}
@@ -167,7 +185,7 @@ class AddressInput extends React.Component {
               />
             </FormLabelGroup>
           </Col>
-          <Col md={2} sm={3} xs={4} className="pr-3">
+          <Col {...width.state} className="js-state-col pr-3">
             <FormLabelGroup
               rowClassName={classnames({ 'mb-0': !showCountry })}
               feedback={error.state}
@@ -192,7 +210,7 @@ class AddressInput extends React.Component {
               />
             </FormLabelGroup>
           </Col>
-          <Col md={4} sm={3} xs={8}>
+          <Col {...width.postal} className="js-postal-col">
             <FormLabelGroup
               rowClassName={classnames({ 'mb-0': !showCountry })}
               label={labels.postal}

--- a/stories/Address.stories.js
+++ b/stories/Address.stories.js
@@ -34,6 +34,8 @@ export const LiveExample = () => (
       showLabels={boolean('showLabels', false)}
       labels={object('labels', AddressInput.defaultProps.labels)}
       hints={object('hints', AddressInput.defaultProps.hints)}
+      cityColClassName={text('cityColClassName', AddressInput.defaultProps.cityColClassName)}
+      stateColClassName={text('stateColClassName', AddressInput.defaultProps.stateColClassName)}
       width={object('width', AddressInput.defaultProps.width)}
     />
   </div>

--- a/stories/Address.stories.js
+++ b/stories/Address.stories.js
@@ -34,6 +34,7 @@ export const LiveExample = () => (
       showLabels={boolean('showLabels', false)}
       labels={object('labels', AddressInput.defaultProps.labels)}
       hints={object('hints', AddressInput.defaultProps.hints)}
+      width={object('width', AddressInput.defaultProps.width)}
     />
   </div>
 );

--- a/test/components/AddressInput.spec.js
+++ b/test/components/AddressInput.spec.js
@@ -456,6 +456,40 @@ describe('AddressInput', () => {
     assert.equal(component.find('.address-component').hostNodes().length, 1);
   });
 
+  describe('cityColClassName', () => {
+    it('should have the default value', () => {
+      const wrapper = shallow(<AddressInput />);
+
+      const cityCol = wrapper.find('.js-city-col');
+      expect(cityCol.hasClass('pr-sm-3')).toEqual(true);
+    });
+
+    it('can have custom class', () => {
+      const wrapper = shallow(<AddressInput cityColClassName="py-5" />);
+
+      const cityCol = wrapper.find('.js-city-col');
+      expect(cityCol.hasClass('pr-sm-3')).toEqual(false);
+      expect(cityCol.hasClass('py-5')).toEqual(true);
+    });
+  });
+
+  describe('stateColClassName', () => {
+    it('should have the default value', () => {
+      const wrapper = shallow(<AddressInput />);
+
+      const cityCol = wrapper.find('.js-state-col');
+      expect(cityCol.hasClass('pr-3')).toEqual(true);
+    });
+
+    it('can have custom class', () => {
+      const wrapper = shallow(<AddressInput stateColClassName="mx-3" />);
+
+      const cityCol = wrapper.find('.js-state-col');
+      expect(cityCol.hasClass('pr-3')).toEqual(false);
+      expect(cityCol.hasClass('mx-3')).toEqual(true);
+    });
+  });
+
   describe('states', () => {
     it('should support different countries', () => {
       const defaultStates = mount(<AddressInput id="test" />);

--- a/test/components/AddressInput.spec.js
+++ b/test/components/AddressInput.spec.js
@@ -469,7 +469,7 @@ describe('AddressInput', () => {
     });
   });
 
-  describe('custom input namme', () => {
+  describe('custom input name', () => {
     const inputName = {
       address1: 'custom_name_address1',
       address2: 'custom_name_address2',
@@ -544,6 +544,52 @@ describe('AddressInput', () => {
         input.simulate('blur');
         assert(onBlur.calledWith(field));
       });
+    });
+  });
+
+  describe('width', () => {
+    it('should have default widths', () => {
+      const wrapper = shallow(<AddressInput />);
+
+      const cityCol = wrapper.find('.js-city-col');
+      expect(cityCol.prop('xs')).toEqual(12);
+      expect(cityCol.prop('sm')).toEqual(6);
+
+      const stateCol = wrapper.find('.js-state-col');
+      expect(stateCol.prop('xs')).toEqual(4);
+      expect(stateCol.prop('sm')).toEqual(3);
+      expect(stateCol.prop('md')).toEqual(2);
+
+      const postalCol = wrapper.find('.js-postal-col');
+      expect(postalCol.prop('xs')).toEqual(8);
+      expect(postalCol.prop('sm')).toEqual(3);
+      expect(postalCol.prop('md')).toEqual(4);
+    });
+
+    it('can have custom col widths', () => {
+      const wrapper = shallow(
+        <AddressInput
+          width={{
+            city: { xs: 12 },
+            state: { xs: 12, lg: 3 },
+            postal: { md: 6, lg: 9 },
+          }}
+        />
+      );
+
+      const cityCol = wrapper.find('.js-city-col');
+      expect(cityCol.prop('xs')).toEqual(12);
+      expect(cityCol.prop('sm')).toEqual(undefined);
+
+      const stateCol = wrapper.find('.js-state-col');
+      expect(stateCol.prop('xs')).toEqual(12);
+      expect(stateCol.prop('sm')).toEqual(undefined);
+      expect(stateCol.prop('lg')).toEqual(3);
+
+      const postalCol = wrapper.find('.js-postal-col');
+      expect(postalCol.prop('xs')).toEqual(undefined);
+      expect(postalCol.prop('md')).toEqual(6);
+      expect(postalCol.prop('lg')).toEqual(9);
     });
   });
 });


### PR DESCRIPTION
Since the column widths are based on the viewport size, if the `Address` component is rendered within an element with a smaller width, the city, state, and postal inputs can get squished and unreadable in some cases.
This makes it so you can override those column widths to handle instances where this could be a problem.

Example before:
<img width="719" alt="Screen Shot 2021-09-15 at 6 36 50 PM" src="https://user-images.githubusercontent.com/759759/133526755-4c55bfbb-648d-410b-9afc-59e5ec264671.png">

After with custom col widths pushing the city to `xs: 12`:
<img width="619" alt="Screen Shot 2021-09-15 at 6 36 17 PM" src="https://user-images.githubusercontent.com/759759/133526775-45329300-4d70-445b-ae81-83f4b6cb83fe.png">
