### PR TITLE
Update responsive prop type of Table component

### DIFF
--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -8,7 +8,7 @@ export interface TableProps extends ReactStrapTableProps {
   striped?: boolean;
   dark?: boolean;
   hover?: boolean;
-  responsive?: boolean;
+  responsive?: boolean | 'sm' | 'md' | 'lg' | 'xl';
   children: React.ReactNode;
 }
 


### PR DESCRIPTION
This is for updating the responsive prop type of `Table` component to match what is actually offered by `reactstrap` `Table` component that is being used.

`reactstrap` table component does not restrict table component to be `boolean` type, it can also be `string` type.
PropType:
https://github.com/reactstrap/reactstrap/blob/8.7.1/src/Table.js#L15
TypeScript type:
https://github.com/reactstrap/reactstrap/blob/8.7.1/types/lib/Table.d.ts#L15

It does not seem to be [documented](https://reactstrap.github.io/components/tables/) as of today (2021 Thu Sep 23), but we could have responsive being 'sm' to make the table only responsive for small sized screen.

This seems to be what bootstrap table is offering for class name `table-responsive{-sm|-md|-lg|-xl}`.
https://github.com/reactstrap/reactstrap/blob/8.7.1/src/Table.js#L57
https://getbootstrap.com/docs/4.0/content/tables/#breakpoint-specific

Instead of having type `boolean | string`, I used `boolean | 'sm' | 'md' | 'lg' | 'xl'` because it is more restrictive to the 4 responsive type options bootstrap provides.