### PR TITLE
feat: add AllowWeakType util

### DIFF
--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -8,6 +8,7 @@ import FilterHeader, { FilterHeaderProps } from './FilterHeader';
 import SortHeader, { SortHeaderProps } from './SortHeader';
 import ListItem, { ListItemProps } from './ListItem';
 import useMap from '../../hooks/useMap';
+import { AllowWeakType } from '../../util/types';
 
 interface Sort {
   property?: string | string [];
@@ -52,7 +53,7 @@ const defaultProps = {
   sortByLabel: 'Sort by',
 };
 
-function List<T extends Item>({
+function List<T extends AllowWeakType<Item>>({
   children: render = defaultProps.children,
   filter,
   filterPlaceholder = defaultProps.filterPlaceholder,

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1,0 +1,1 @@
+export type AllowWeakType<T> = Record<string, never> extends T ? any : T;


### PR DESCRIPTION
We want to allow weak types in the case of typing generics for components like lists or tables in which we support optional properties like `key` or `expanded`. This will allow usage of the components in typescript without type errors if users choose not to provide any of the optional properties.