### PR TITLE
fix: remove weak type extension

### DIFF
--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -17,6 +17,7 @@ interface Sort {
 interface Item {
   expanded?: boolean;
   key?: string;
+  [key: string]: any;
 }
 
 export interface ListProps<T> extends Omit<ListGroupProps, 'onSelect'> {

--- a/src/components/List/ListItem.tsx
+++ b/src/components/List/ListItem.tsx
@@ -31,7 +31,6 @@ function ListItem<T>({
   ...props
 }: ListItemProps<T>) {
   const isExpandable = onExpand !== undefined;
-  // @ts-ignore
   const ExpandedItem = isExpandable ? onExpand!(item) : undefined;
   const [expanded, setExpanded] = useState(defaultExpanded);
   const [id] = useState(() => uniqueId('listitem-'));
@@ -50,7 +49,7 @@ function ListItem<T>({
               type={select}
               checked={selected}
               label={<span className="sr-only">Select {itemId}</span>}
-              onChange={e => onSelect(item, e.target.checked)}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => onSelect(item, e.target.checked)}
             />
           </div>
         )}

--- a/src/components/List/SortHeader.tsx
+++ b/src/components/List/SortHeader.tsx
@@ -25,7 +25,7 @@ const SortHeader = ({ ascending, sortByLabel, sortOptions, sortProperty, onChang
       <CustomInput
         id={sortId}
         type="select"
-        onChange={(e) => {
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
           const value = e.target.value;
           onChangeProperty(value && value.includes(',') ? value.split(',') : value);
         }}


### PR DESCRIPTION
Typescript will complain if list items don't have one of `expanded` or `key` properties defined. This is not ideal, so we're adding `[key: string]: any` to prevent `Item` from being a weak type.