### PR TITLE
Add allowed size types for font awesome icons

### DIFF
--- a/src/components/icon/FontAwesomeAPM.tsx
+++ b/src/components/icon/FontAwesomeAPM.tsx
@@ -24,7 +24,7 @@ export interface FontAwesomeAPMProps extends React.HTMLAttributes<any> {
   name: string,
   pulse?: boolean,
   rotate?: 90 | 180 | 270;
-  size?: 'lg' | '2x' | '3x' | '4x' | '5x';
+  size?: 'xs' |'sm' | 'lg' | '2x' | '3x' | '4x' | '5x';
   spin?: boolean;
   stack?: '1x' | '2x';
   tag?: keyof JSX.IntrinsicElements;

--- a/stories/Icon.stories.js
+++ b/stories/Icon.stories.js
@@ -15,7 +15,7 @@ export default {
 export const LiveExample = () => (
   <Icon
     name={text('name', 'motorcycle')}
-    size={select('size', ['', 'lg', '2x', '3x', '4x', '5x'], '4x')}
+    size={select('size', ['', 'xs', 'sm', 'lg', '2x', '3x', '4x', '5x'], '4x')}
     spin={boolean('spin', false)}
     pulse={boolean('pulse', false)}
     rotate={select('rotate', ['', '90', '180', '270'], '')}
@@ -25,7 +25,7 @@ export const LiveExample = () => (
 );
 
 export const AvailableIcons = () => {
-  const size = select('size', ['', 'lg', '2x', '3x', '4x', '5x'], '4x');
+  const size = select('size', ['', 'xs', 'sm', 'lg', '2x', '3x', '4x', '5x'], '4x');
   return (
     <div>
       <em>Hover over icon to view name:</em><br />
@@ -78,6 +78,8 @@ export const Buttons = () => (
 
 export const Size = () => (
   <div>
+    <Icon name="calendar" size="xs" /> xs<br />
+    <Icon name="calendar" size="sm" /> sm<br />
     <Icon name="calendar" size="lg" /> lg<br />
     <Icon name="calendar" size="2x" /> 2x<br />
     <Icon name="calendar" size="3x" /> 3x<br />


### PR DESCRIPTION
Only adds the smallest 2 sizes.  There are still a bunch of larger
sizes (6x-10x) allowed by FA that we may also need to add in the future.