### PR TITLE
Add component for truncating text

### DIFF
--- a/src/components/TruncatedText.tsx
+++ b/src/components/TruncatedText.tsx
@@ -1,0 +1,41 @@
+import React, { useState } from 'react';
+import { TooltipProps, UncontrolledTooltipProps } from 'reactstrap';
+import Tooltip from './Tooltip';
+
+
+interface TruncatedTextProps {
+  text: string;
+  targetId: string;
+  charLimit: number;
+  tooltip: boolean;
+  placement: UncontrolledTooltipProps['placement'];
+  tooltipProps: TooltipProps
+}
+
+let count = 0;
+function getID() {
+  return `truncated-text-${count++}`; // eslint-disable-line no-plusplus
+}
+const TruncatedText = ({ text, targetId, charLimit = 50, tooltip = true, placement = 'top', tooltipProps }: TruncatedTextProps) => {
+  const [id] = useState(targetId || getID());
+  return (
+    <>
+      <span id={id}>
+        {text && text.length > charLimit ? `${text.substring(0, charLimit).trim()}...` : text}
+      </span>
+      {(text && text.length > charLimit && tooltip) && (
+        <Tooltip
+          {...tooltipProps}
+          placement={placement}
+          target={id}
+          className={`js-truncated-${id}`}
+        >
+          {text}
+        </Tooltip>)}
+    </>
+  );
+};
+
+TruncatedText.displayName = 'TruncatedText';
+
+export default TruncatedText;

--- a/src/index.ts
+++ b/src/index.ts
@@ -166,6 +166,7 @@ import Tooltip from './components/Tooltip';
 import UncontrolledTable from './components/UncontrolledTable';
 import Waiting from './components/Waiting';
 import TooltipButton from './components/TooltipButton';
+import TruncatedText from './components/TruncatedText';
 
 export {
   // reactstrap
@@ -331,4 +332,5 @@ export {
   UncontrolledTable,
   Waiting,
   TooltipButton,
+  TruncatedText
 };

--- a/stories/TruncatedText.stories.js
+++ b/stories/TruncatedText.stories.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { boolean, number, select, text } from '@storybook/addon-knobs';
+import { TruncatedText } from '../src';
+
+export default {
+  title: 'TruncatedText',
+  component: TruncatedText,
+};
+
+export const LiveExample = () => (
+  <>
+    <div>
+      <TruncatedText
+        targetId="TruncatedTextExample"
+        charLimit={number('charLimit', 20)}
+        text={text('text', 'The quick brown fox jumps over the lazy dog')}
+        tooltip={boolean('tooltip', true)}
+        placement={select('placement', ['top', 'bottom', 'left', 'right'])}
+      />
+    </div>
+  </>
+);

--- a/test/components/TruncatedText.spec.js
+++ b/test/components/TruncatedText.spec.js
@@ -1,0 +1,58 @@
+import React from 'react';
+import assert from 'assert';
+import { mount } from 'enzyme';
+
+import { TruncatedText } from '../../src';
+
+describe('<TruncatedText />', () => {
+  it('renders text sucessfully', () => {
+    const wrapper = mount(
+      <TruncatedText targetId="target" text="cool text" />
+    );
+
+    const span = wrapper.find('span').first();
+    assert.equal(span.exists(), true);
+    assert(span.text().includes('cool text'));
+  });
+
+  it('truncates text correctly', () => {
+    const div = document.createElement('div');
+    document.body.appendChild(div);
+    const wrapper = mount(<TruncatedText
+      targetId="target"
+      text="cool text that is over 20 characters long"
+      charLimit={20}
+    />, { attachTo: div });
+
+    const span = wrapper.find('span').first();
+    assert.equal(span.exists(), true);
+    assert(span.text().includes('cool text that is ov...'));
+  });
+
+  it('renders the tooltip with full text', () => {
+    const div = document.createElement('div');
+    document.body.appendChild(div);
+    const wrapper = mount(<TruncatedText
+      targetId="target"
+      text="cool text that is over 20 characters long"
+      charLimit={20}
+    />, { attachTo: div });
+
+    const tooltip = wrapper.find('Tooltip').first();
+    assert.equal(tooltip.exists(), true);
+    assert.equal(tooltip.props().children, 'cool text that is over 20 characters long');
+  });
+
+  it('renders with no props', () => {
+    const div = document.createElement('div');
+    document.body.appendChild(div);
+    const wrapper = mount(<TruncatedText />, { attachTo: div });
+
+    const span = wrapper.find('span').first();
+    assert.equal(span.exists(), true);
+    assert.equal(span.text(), '');
+
+    const tooltip = wrapper.find('Tooltip').first();
+    assert.equal(tooltip.exists(), false);
+  });
+});


### PR DESCRIPTION
A component that can truncate text to a character limit. It can optionally display the original text in a `Tooltip` on hover.

![image](https://user-images.githubusercontent.com/5304671/148621270-584096b4-2689-45ad-94ea-80e9b25d0204.png)
  