### PR TITLE
Add visible rows notification to UncontrolledTable

### DIFF
--- a/stories/Table.stories.js
+++ b/stories/Table.stories.js
@@ -156,6 +156,7 @@ export const UncontrolledTableExample = () => (
       onSelect={action('onSelect')}
       onSort={action('onSort')}
       onPageChange={action('onPageChange')}
+      onVisibleRowsChange={action('onVisibleRowsChange')}
     />
   </div>
 );

--- a/test/components/UncontrolledTable.spec.js
+++ b/test/components/UncontrolledTable.spec.js
@@ -554,6 +554,60 @@ describe('<UncontrolledTable />', () => {
     assert(instance.expanded({ name: 'Alpha' }) === true);
   });
 
+  describe('onVisibleRowsChange', () => {
+    it('calls onVisibleRowsChange when the page changes', () => {
+      const columns = [{ header: 'Name', cell: row => row }];
+      const rows = ['Alpha', 'Bravo', 'Charlie', 'Delta', 'Echo', 'Foxtrot', 'Golf', 'Hotel'];
+      const onVisibleRowsChange = sinon.stub();
+      const wrapper = mount(
+        <UncontrolledTable
+          columns={columns}
+          rows={rows}
+          paginated
+          pageSize={4}
+          onVisibleRowsChange={onVisibleRowsChange}
+        />
+      );
+
+      wrapper.find('.page-link').last().simulate('click');
+      sinon.assert.calledWith(onVisibleRowsChange, ['Echo', 'Foxtrot', 'Golf', 'Hotel']);
+    });
+
+    it('calls onVisibleRowsChange when pagination is enabled', () => {
+      const columns = [{ header: 'Name', cell: row => row }];
+      const rows = ['Alpha', 'Bravo', 'Charlie', 'Delta', 'Echo', 'Foxtrot', 'Golf', 'Hotel'];
+      const onVisibleRowsChange = sinon.stub();
+      const wrapper = mount(
+        <UncontrolledTable
+          columns={columns}
+          rows={rows}
+          pageSize={4}
+          onVisibleRowsChange={onVisibleRowsChange}
+        />
+      );
+
+      sinon.assert.notCalled(onVisibleRowsChange);
+
+      wrapper.setProps({ paginated: true });
+      sinon.assert.calledWith(onVisibleRowsChange, ['Alpha', 'Bravo', 'Charlie', 'Delta']);
+    });
+
+    it('does not call onVisibleRowsChange when a row is expanded', () => {
+      const columns = [{ header: 'Name', cell: row => row.name }];
+      const rows = [{ name: 'Alpha' }, { name: 'Bravo' }];
+      const onVisibleRowsChange = sinon.stub();
+
+      const wrapper = mount(
+        <UncontrolledTable columns={columns} rows={rows} onVisibleRowsChange={onVisibleRowsChange} />
+      );
+      const instance = wrapper.instance();
+      instance.toggleExpanded({ name: 'Alpha' });
+      assert(instance.expanded({ name: 'Alpha' }) === true);
+
+      sinon.assert.notCalled(onVisibleRowsChange);
+    });
+  });
+
   describe('isEqualUsingKeys()', () => {
     let wrapper;
 


### PR DESCRIPTION
- Add new prop, `onVisibleRowsChanged` to notify when a new set of rows is (potentially) loaded in the current page
- Use `componentDidUpdate` to inspect the state/props that might indicate an updated set of rows
- Add a couple of instance methods to help in getting the rows that should be visible, and to determine it things changed
- Tests and story updated