### PR TITLE
fix: report visible rows on initial render

### DIFF
--- a/src/components/UncontrolledTable.js
+++ b/src/components/UncontrolledTable.js
@@ -196,6 +196,10 @@ export default class UncontrolledTable extends React.Component {
     }
   }
 
+  componentDidMount() {
+    this.props.onVisibleRowsChange(this.getVisibleRows());
+  }
+
   render() {
     const { page } = this.state;
     const { ascending, column } = this.state.sort;

--- a/test/components/UncontrolledTable.spec.js
+++ b/test/components/UncontrolledTable.spec.js
@@ -586,7 +586,7 @@ describe('<UncontrolledTable />', () => {
         />
       );
 
-      sinon.assert.notCalled(onVisibleRowsChange);
+      sinon.assert.calledOnce(onVisibleRowsChange);
 
       wrapper.setProps({ paginated: true });
       sinon.assert.calledWith(onVisibleRowsChange, ['Alpha', 'Bravo', 'Charlie', 'Delta']);
@@ -604,7 +604,7 @@ describe('<UncontrolledTable />', () => {
       instance.toggleExpanded({ name: 'Alpha' });
       assert(instance.expanded({ name: 'Alpha' }) === true);
 
-      sinon.assert.notCalled(onVisibleRowsChange);
+      sinon.assert.calledOnce(onVisibleRowsChange);
     });
   });
 


### PR DESCRIPTION
In https://github.com/appfolio/react-gears/pull/943, logic was added to `componenDidUpdate()` to call the `onVisibleRowsChange` prop when the props/state changed in a way that would cause the contents of the current table page to change.

Unfortunately, this did not take in to account the initial render. `componenDidUpdate()` is not called at that time. In this PR, we call `componenDidMount()` to get that initial call to `onVisibleRowsChange`