### PR TITLE
fix: currencyinput should only toString if it exists

### DIFF
--- a/src/components/CurrencyInput.tsx
+++ b/src/components/CurrencyInput.tsx
@@ -82,7 +82,7 @@ const CurrencyInput: FunctionComponent<Props> = ({
    * https://github.com/uNmAnNeR/imaskjs/blob/master/packages/react-imask/src/mixin.ts#L139-L147
    */
   if (value !== undefined) {
-    maskedProps.value = value.toString();
+    maskedProps.value = value?.toString();
   }
 
   if (innerRef) {

--- a/src/components/List/ListItem.tsx
+++ b/src/components/List/ListItem.tsx
@@ -12,10 +12,10 @@ export interface ListItemProps<T> extends Omit<ListGroupItemProps, 'onSelect'> {
   expanded?: boolean,
   item: T,
   onExpand?: (item: T) => React.ReactNode | undefined,
-  onSelect: (item: T, checked?: boolean) => void
+  onSelect?: (item: T, checked?: boolean) => void
   select?: 'checkbox' | 'radio' | 'switch' | '',
   selected?: boolean,
-  selectable: (item: T) => boolean
+  selectable?: (item: T) => boolean
 }
 
 function ListItem<T>({
@@ -51,8 +51,8 @@ function ListItem<T>({
               type={select}
               checked={selected}
               label={<span className="sr-only">Select {itemId}</span>}
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) => onSelect(item, e.target.checked)}
-              disabled={!selectable(item)}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => onSelect && onSelect(item, e.target.checked)}
+              disabled={selectable ? !selectable(item) : false}
             />
           </div>
         )}

--- a/test/components/CurrencyInput.spec.js
+++ b/test/components/CurrencyInput.spec.js
@@ -38,6 +38,11 @@ describe('<CurrencyInput />', () => {
     expect(wrapper.find('input').getDOMNode().value).toEqual('12,123');
   });
 
+  it('should still render if null is provided to value', () => {
+    const component = mount(<CurrencyInput onChange={callback} value={null} />);
+    expect(component.find('input').length).toBeTruthy();
+  });
+
   describe('thousands separators', () => {
     it('should default to true', () => {
       const component = mount(<CurrencyInput onChange={callback} value="123,456,789.99999" />);


### PR DESCRIPTION
toString fails if provided with null (Seems like a test only use case). Typescript should catch this, but not everyone uses typescript yet so just providing a fix for null values.

ListItem should have selectable and onSelect as optional. This allows devs to not have to supply empty props.

For FormRow, I attempted to remove the index signature and I then get the correct type on hover
![image](https://user-images.githubusercontent.com/5122541/151601313-e3bd8824-d8a6-4a2c-979d-c0ce98387298.png)
But then the actual parameter used thinks it is of `any` type. I want to research more on why that happens, but don't want to prevent property from updating.

We might want to update the reactstrap types for Input