### PR TITLE
fix: allow containerClassName prop

### DIFF
--- a/src/components/FormChoice.d.ts
+++ b/src/components/FormChoice.d.ts
@@ -4,6 +4,7 @@ interface FormChoiceProps extends Omit<React.InputHTMLAttributes<HTMLOptionEleme
   inline?: boolean;
   disabled?: boolean;
   checked?: boolean;
+  containerClassName?: string;
   type: 'checkbox' | 'radio' | 'select';
   value: string;
   selected?: boolean;


### PR DESCRIPTION
This prop was already included in the FormChoice propTypes and is used,
but it was mistakenly ommitted from the type declaration.