### PR TITLE
fix: remove small uppercase style from SummaryBox

### DIFF
--- a/src/components/SummaryBoxItem.tsx
+++ b/src/components/SummaryBoxItem.tsx
@@ -40,7 +40,7 @@ const SummaryBoxItem: FunctionComponent<SummaryBoxItemProps> = ({
       {...props}
     >
       <CardBody className={bodyClassNames}>
-        <small className="text-muted text-uppercase">{label}</small>
+        <span className="text-muted">{label}</span>
         <div className={valueClassNames}>{value}</div>
       </CardBody>
     </Card>

--- a/test/components/SummaryBoxItem.spec.js
+++ b/test/components/SummaryBoxItem.spec.js
@@ -9,14 +9,14 @@ describe('<SummaryBoxItem />', () => {
     const component = mount(<SummaryBoxItem label="Hello" value="World" />);
     assert(component);
     assert(component.find('.h3').text(), 'Hello');
-    assert(component.find('small').text(), 'World');
+    assert(component.find('span').text(), 'World');
   });
 
   it('should show the default label and value if none specified', () => {
     const component = mount(<SummaryBoxItem />);
     assert(component);
     assert(component.find('.h3').text(), '--');
-    assert(component.find('small').text(), '--');
+    assert(component.find('span').text(), '--');
   });
 
   it('should reverse when specified', () => {


### PR DESCRIPTION
https://trello.com/c/PYD67I86/61-summarybox-label-text