### PR TITLE
fix: better stories for popover to eliminate styling confusion

### DIFF
--- a/stories/Popover.stories.js
+++ b/stories/Popover.stories.js
@@ -12,6 +12,38 @@ export const LiveExample = () => {
   const [open, setOpen] = useState(false);
 
   return (
+    <>
+      <p>
+        Click <strong id="LivePopoverExample">HERE</strong> to launch it!
+      </p>
+      <Popover
+        isOpen={open}
+        target="LivePopoverExample"
+        trigger={select('trigger', ['click', 'hover', 'focus'], 'click')}
+        toggle={(e) => {
+          setOpen(!open);
+          action('toggle')(e);
+        }}
+        placement={select('placement', ['top', 'bottom', 'left', 'right'], 'bottom')}
+      >
+        <PopoverHeader>Title of the Popover</PopoverHeader>
+        <PopoverBody>
+          <h5>You can do many things</h5>
+          <ul>
+            <li>Add a popover body</li>
+            <li>Add a popover header</li>
+            <li>Control the popover state externally</li>
+          </ul>
+        </PopoverBody>
+      </Popover>
+    </>
+  );
+};
+
+export const CustomizedBody = () => {
+  const [open, setOpen] = useState(false);
+
+  return (
     <div>
       <p>
         I can be placed in context to provide some contextual{' '}
@@ -28,15 +60,20 @@ export const LiveExample = () => {
         placement={select('placement', ['top', 'bottom', 'left', 'right'], 'bottom')}
       >
         <PopoverBody>
-          <h5>{text('PopoverTitle', 'Hello World')}</h5>
-          {text('PopoverBody', 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.')}
+          <div style={{ display: 'flex', flexDirection: 'column' }}>
+            <div style={{ backgroundColor: 'red', color: 'white', padding: '1rem' }}>
+              <h5>You can do whatever you want in the body</h5>
+            </div>
+            <Button>Click this to do things*</Button>
+            <sub>*the button doesn't do anything</sub>
+          </div>
         </PopoverBody>
       </Popover>
     </div>
   );
 };
 
-export const Uncontrolled = () => (
+export const UncontrolledExample = () => (
   <div>
     <Button id="UncontrolledPopover" type="button">
       Launch Popover


### PR DESCRIPTION
The existing popover stories introduced some styling confusion as the "customized" example looked too much like the example that uses the standard `<PopoverHeader />`/`<PopoverBody />` combination.

This makes an explicit, unambiguous customized example, and leave the standard ones fairly plain.