### PR TITLE
fix: update list icons to match prod

### DIFF
--- a/src/components/List/SortHeader.tsx
+++ b/src/components/List/SortHeader.tsx
@@ -63,7 +63,7 @@ const SortHeader = ({
           id="sort-button"
           onClick={() => onChangeAscending(!ascending)}
         >
-          <Icon name={ascending ? 'sort-amount-up-alt' : 'sort-amount-down'} size="lg" />
+          <Icon name={ascending ? 'arrow-down' : 'arrow-up'} size="lg" />
           <span className="sr-only">Change Sort Direction</span>
         </Button>
       )}

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -8,7 +8,7 @@ import SelectArrow from './SelectArrow';
 import SelectMultiValue from './SelectMultiValue.js';
 import Option from './SelectOption.js';
 
-const getSelectArrow = ({ isOpen, arrowRenderer }) => (
+const getSelectArrow = (isOpen, arrowRenderer) => (
   <SelectArrow isOpen={isOpen} render={arrowRenderer} />
 );
 


### PR DESCRIPTION
Don't really know how the icons were different in prod, but they were. It doesn't seem like props can update the icon either, and the archived @appfolio/react-gears-list repo doesn't contain the new Icon. Although this seems to fix it.