### PR TITLE
fix(select): have consistent clear (x) position

### DIFF
--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -12,7 +12,9 @@ const getSelectArrow = (isOpen, arrowRenderer) => (
   <SelectArrow isOpen={isOpen} render={arrowRenderer} />
 );
 
-const getCloseButton = () => <Close tabIndex={-1} style={{ fontSize: '.5rem' }} />;
+const getCloseButton = () => (
+  <Close className="d-flex" tabIndex={-1} style={{ fontSize: '.5rem' }} />
+);
 
 const Select = ({
   arrowRenderer,


### PR DESCRIPTION
Fix for this issue found in firefox only:
![image](https://user-images.githubusercontent.com/5122541/161153877-4659cc4c-0df5-4c3d-8c96-b993aaa4a6f2.png)

Looks ok in firefox now
![image](https://user-images.githubusercontent.com/5122541/161153943-3a186748-92a5-45c3-83c4-24fb020fbf24.png)
