### PR TITLE
Use BS5 classes instead of inline styles

### DIFF
--- a/src/components/FeatureBanner/FeatureBanner.tsx
+++ b/src/components/FeatureBanner/FeatureBanner.tsx
@@ -26,8 +26,8 @@ const FeatureBanner: FC<FeatureBannerProps> = ({
   return (
     <Alert color={color} className="align-items-center d-flex p-0" fade={false}>
       <h2 className={`${alertStyle} text-center m-0 px-3 d-none d-sm-block`}>{alertText}</h2>
-      <div className="body d-flex flex-wrap p-3 w-100">
-        <div className="info me-auto">
+      <div className="d-flex flex-row flex-wrap p-3 w-100">
+        <div className="flex-fill me-auto">
           <div className="d-inline-block m-0">
             <h2 className={`${alertStyle} d-inline d-sm-none me-2`}>{alertText}</h2>
             <h3 className="d-inline">{title}</h3>
@@ -36,21 +36,6 @@ const FeatureBanner: FC<FeatureBannerProps> = ({
         </div>
         <div className="d-inline-block my-auto">{children}</div>
       </div>
-      <style jsx>
-        {`
-          .body {
-            flex-direction: row;
-          }
-
-          .body @media (min-width: 576px) {
-            border-start: 1px solid rgba(0, 0, 0, 0.1);
-          }
-
-          .info {
-            flex: 1 1 auto;
-          }
-        `}
-      </style>
     </Alert>
   );
 };


### PR DESCRIPTION
This removes the inline (`<style jsx>`) styles for feature banner.
2 of the rules are now handled thanks to Bootstrap 5 classes being available.
There was an attempt at a media query that places a border to the left of the "body" area. After discussing this with @arstewar , the decision was made that this component is better without the border, so it could be removed completely (rather than fixed).