### PR TITLE
fix: jumpy combobox from popper

### DIFF
--- a/src/components/Combobox/Combobox.tsx
+++ b/src/components/Combobox/Combobox.tsx
@@ -426,21 +426,7 @@ function Combobox<T>({
         <DropdownMenu
           data-testid="combobox-menu"
           className="p-0 w-100"
-          modifiers={[
-            {
-              name: 'setMaxHeight',
-              enabled: true,
-              fn: ({ state }: ModifierArguments<any>) => {
-                state.styles.popper = {
-                  ...state.styles.popper,
-                  overflowY: 'auto',
-                  maxHeight: menuMaxHeight || '12rem',
-                };
-              },
-              phase: 'beforeWrite',
-              requires: ['computeStyles'],
-            },
-          ]}
+          style={{ maxHeight: menuMaxHeight || '12rem', overflowY: 'auto' }}
           {...dropdownProps}
           ref={dropdownMenu}
           role="listbox"


### PR DESCRIPTION
Popper was computing the flip style before applying maxHeight

This causes issues and makes the combobox jumpy. So it should fix the below video.

https://user-images.githubusercontent.com/5122541/161171659-2a43b365-f982-4b3c-8436-32318476dbcc.mov

