### PR TITLE
fix: conform popover to coastline look

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,7 +1,17 @@
-<link id="theme" rel="stylesheet" href="https://appfolio.github.io/bootstrap-coastline/bootstrap-coastline.css">
-<link rel="stylesheet" href="https://apm-prod-frontend-assets.s3.amazonaws.com/icons/font-awesome/5.14.0/css/all.min.css">
-<link rel="stylesheet" href="https://apm-prod-frontend-assets.s3.amazonaws.com/icons/font-awesome/5.14.0/css/v4-shims.min.css">
-<link href="https://use.typekit.net/uao7jmm.css" rel="stylesheet">
+<link
+  id="theme"
+  rel="stylesheet"
+  href="https://appfolio.github.io/bootstrap-coastline/bootstrap-coastline.css"
+/>
+<link
+  rel="stylesheet"
+  href="https://apm-prod-frontend-assets.s3.amazonaws.com/icons/font-awesome/5.14.0/css/all.min.css"
+/>
+<link
+  rel="stylesheet"
+  href="https://apm-prod-frontend-assets.s3.amazonaws.com/icons/font-awesome/5.14.0/css/v4-shims.min.css"
+/>
+<link href="https://use.typekit.net/uao7jmm.css" rel="stylesheet" />
 <style>
   #story-root {
     margin-bottom: 3rem;

--- a/src/components/Popover/Popover.stories.js
+++ b/src/components/Popover/Popover.stories.js
@@ -32,12 +32,13 @@ export const LiveExample = () => {
       >
         <PopoverHeader>Title of the Popover</PopoverHeader>
         <PopoverBody>
-          <h5>You can do many things</h5>
+          <b>You can do many things</b>
           <ul>
             <li>Add a popover body</li>
             <li>Add a popover header</li>
             <li>Control the popover state externally</li>
           </ul>
+          <b>...or put in any components you wish.</b>
         </PopoverBody>
       </Popover>
     </>

--- a/src/components/Popover/PopoverHeader.tsx
+++ b/src/components/Popover/PopoverHeader.tsx
@@ -1,3 +1,10 @@
-import { PopoverHeader } from 'reactstrap';
+import type { FC } from 'react';
+import React from 'react';
+import type { PopoverHeaderProps } from 'reactstrap';
+import { PopoverHeader as InternalPopoverHeader } from 'reactstrap';
+
+const PopoverHeader: FC<PopoverHeaderProps> = ({ tag = 'h4', ...props }) => (
+  <InternalPopoverHeader tag={tag} {...props} />
+);
 
 export default PopoverHeader;


### PR DESCRIPTION
- Change the popover story to remove the h4 from the popover body to remove confusion/conflict with the popover header.
- Force the popover header to default to an `<h4>` for its tag (rather than `<h3>` from reactstrap)