### PR TITLE
fix: allow state/country input to be empty string

### DIFF
--- a/src/components/Address/CountryInput.tsx
+++ b/src/components/Address/CountryInput.tsx
@@ -6,7 +6,7 @@ import Input from '../Input/Input';
 import COUNTRIES from './util/Countries'; // TODO i18n country names based on locale
 
 interface CountryInputProps extends Omit<InputProps, 'type' | 'onChange'> {
-  onChange?: (value: string | null) => void;
+  onChange?: (value: string) => void;
   placeholder?: string;
   value?: string;
 }
@@ -31,7 +31,7 @@ const CountryInput: FC<CountryInputProps> = ({
       disabled={disabled}
       id={id}
       name={name}
-      onChange={(e) => onChange(e.target.value === '' ? null : e.target.value)}
+      onChange={(e) => onChange(e.target.value)}
     >
       <option value="">{placeholder}</option>
       {COUNTRIES.map((country) => (

--- a/src/components/Address/StateInput.tsx
+++ b/src/components/Address/StateInput.tsx
@@ -21,7 +21,7 @@ interface StateInputProps extends Omit<InputProps, 'type' | 'onChange'> {
   disabled?: boolean;
   id?: string;
   name?: string;
-  onChange?: (value: string | null) => any;
+  onChange?: (value: string) => any;
   placeholder?: string;
   value?: string;
 }
@@ -56,7 +56,7 @@ const StateInput: FC<StateInputProps> = ({
       disabled={disabled}
       id={id}
       name={name}
-      onChange={(e) => onChange(e.target.value === '' ? null : e.target.value)}
+      onChange={(e) => onChange(e.target.value)}
     >
       <option value="">{placeholder}</option>
       {STATES.map((state) => (


### PR DESCRIPTION
Setting the value to `null` causes the component to go from a controlled component to an uncontrolled component. 