### PR TITLE
Add API agnostic FeedbackButton

### DIFF
--- a/src/components/FeedbackButton/FeedbackButton.spec.tsx
+++ b/src/components/FeedbackButton/FeedbackButton.spec.tsx
@@ -1,0 +1,387 @@
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  waitForElementToBeRemoved,
+  within,
+} from '@testing-library/react';
+import React from 'react';
+import FeedbackButton from './FeedbackButton';
+
+describe('<FeedbackButton />', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('submits feedback via doSubmit callback with all default properties', async () => {
+    const doSubmit = jest.fn();
+    const { getByRole, findByRole } = render(
+      <FeedbackButton
+        feature="test_feature"
+        recipient="test_recipient@example.com"
+        doSubmit={doSubmit}
+      />
+    );
+
+    const feedbackButton = getByRole('button');
+    expect(feedbackButton.textContent).toEqual('Feedback');
+    expect(feedbackButton).toHaveClass('btn-outline-primary');
+
+    fireEvent.click(feedbackButton);
+
+    const feedbackModal = await findByRole('dialog');
+
+    const heading = within(feedbackModal).getByRole('heading', { level: 5 });
+    expect(heading.textContent).toEqual('Give Feedback');
+
+    const ratingSubtitle = within(feedbackModal).getByText(
+      'So far, how satisfied are you with this feature?'
+    );
+    expect(ratingSubtitle).toHaveClass('text-danger');
+    const ratingAsterisk = within(ratingSubtitle).getByText('*');
+    expect(ratingAsterisk).toHaveClass('text-danger');
+    const feedbackModalRating = within(feedbackModal).getByTestId('feedback-modal-rating');
+
+    expect(within(feedbackModalRating).queryAllByText('Not satisfied at all')).toHaveLength(1);
+
+    expect(within(feedbackModalRating).queryAllByText('Very satisfied')).toHaveLength(1);
+
+    const radioButtonContainers = within(feedbackModalRating).queryAllByTestId(/rating-[1-5]/);
+    expect(radioButtonContainers).toHaveLength(5);
+
+    let chosenRadioButton: HTMLElement | undefined;
+
+    [1, 2, 3, 4, 5].forEach((rating: number) => {
+      const radioButtonContainer = within(feedbackModalRating).getByTestId(`rating-${rating}`);
+      within(radioButtonContainer).getByText(rating);
+      const radioButton = within(radioButtonContainer).getByRole('radio');
+
+      expect(radioButton).toHaveAttribute('data-value', `${rating}`);
+
+      if (rating === 5) {
+        chosenRadioButton = radioButton;
+      }
+    });
+
+    fireEvent.click(chosenRadioButton!);
+
+    const commentSubtitle = within(feedbackModal).getByText(
+      'How could we improve the way this works for you?'
+    );
+    expect(commentSubtitle).toHaveClass('text-danger');
+    const commentAsterisk = within(commentSubtitle).getByText('*');
+    expect(commentAsterisk).toHaveClass('text-danger');
+    const commentInput = within(feedbackModal).getByPlaceholderText(
+      'Please give as much detail as you can. Thanks!'
+    );
+
+    fireEvent.change(commentInput, { target: { value: 'This is a comment!' } });
+
+    const buttonToolbar = within(feedbackModal).getByRole('toolbar');
+    within(buttonToolbar).getByText('Cancel');
+    const sendButton = within(buttonToolbar).getByText('Send');
+
+    act(() => {
+      fireEvent.click(sendButton);
+    });
+    expect(within(buttonToolbar).getAllByRole('button')[0].textContent).toEqual('Please Wait...');
+    await waitForElementToBeRemoved(feedbackModal);
+
+    expect(doSubmit.mock.calls).toEqual([
+      [
+        {
+          feature: 'test_feature',
+          recipient: 'test_recipient@example.com',
+          cc: undefined,
+          rating: 5,
+          comment: 'This is a comment!',
+        },
+      ],
+    ]);
+  });
+
+  it('submits feedback via doSubmit callback with overridden default properties', async () => {
+    const doSubmit = jest.fn();
+    const { getByRole, findByRole } = render(
+      <FeedbackButton
+        feature="test_feature"
+        recipient="test_recipient@example.com"
+        doSubmit={doSubmit}
+        backdrop
+        cancelButtonText="Cancel2"
+        color="secondary"
+        outline={false}
+        commentPlaceholder="Please give as much detail as you can. Thanks!2"
+        commentSubtitle="How could we improve the way this works for you?2"
+        highRatingText="Very satisfied2"
+        lowRatingText="Not satisfied at all2"
+        modalTitle="Give Feedback2"
+        pleaseWaitButtonText="Please Wait...2"
+        ratingSubtitle="So far, how satisfied are you with this feature?2"
+        submitButtonText="Send2"
+        ratingIncluded
+        ratingRequired={false}
+        commentIncluded
+        commentRequired={false}
+      />
+    );
+
+    const feedbackButton = getByRole('button');
+    expect(feedbackButton.textContent).toEqual('Feedback');
+    expect(feedbackButton).toHaveClass('btn-secondary');
+
+    fireEvent.click(feedbackButton);
+
+    const feedbackModal = await findByRole('dialog');
+
+    const heading = within(feedbackModal).getByRole('heading', { level: 5 });
+    expect(heading.textContent).toEqual('Give Feedback2');
+
+    const ratingSubtitle = within(feedbackModal).getByText(
+      'So far, how satisfied are you with this feature?2'
+    );
+    expect(ratingSubtitle).not.toHaveClass('text-danger');
+
+    const feedbackModalRating = within(feedbackModal).getByTestId('feedback-modal-rating');
+
+    expect(within(feedbackModalRating).queryAllByText('Not satisfied at all2')).toHaveLength(1);
+
+    expect(within(feedbackModalRating).queryAllByText('Very satisfied2')).toHaveLength(1);
+
+    const radioButtonContainers = within(feedbackModalRating).queryAllByTestId(/rating-[1-5]/);
+    expect(radioButtonContainers).toHaveLength(5);
+
+    let chosenRadioButton: HTMLElement | undefined;
+
+    [1, 2, 3, 4, 5].forEach((rating: number) => {
+      const radioButtonContainer = within(feedbackModalRating).getByTestId(`rating-${rating}`);
+      within(radioButtonContainer).getByText(rating);
+      const radioButton = within(radioButtonContainer).getByRole('radio');
+
+      expect(radioButton).toHaveAttribute('data-value', `${rating}`);
+
+      if (rating === 5) {
+        chosenRadioButton = radioButton;
+      }
+    });
+
+    fireEvent.click(chosenRadioButton!);
+
+    const commentSubtitle = within(feedbackModal).getByText(
+      'How could we improve the way this works for you?2'
+    );
+    expect(commentSubtitle).not.toHaveClass('text-danger');
+    const commentInput = within(feedbackModal).getByPlaceholderText(
+      'Please give as much detail as you can. Thanks!2'
+    );
+
+    fireEvent.change(commentInput, { target: { value: 'This is a comment!' } });
+
+    const buttonToolbar = within(feedbackModal).getByRole('toolbar');
+    within(buttonToolbar).getByText('Cancel2');
+    const sendButton = within(buttonToolbar).getByText('Send2');
+
+    act(() => {
+      fireEvent.click(sendButton);
+    });
+
+    expect(within(buttonToolbar).getAllByRole('button')[0].textContent).toEqual('Please Wait...2');
+
+    await waitForElementToBeRemoved(feedbackModal);
+
+    expect(doSubmit.mock.calls).toEqual([
+      [
+        {
+          feature: 'test_feature',
+          recipient: 'test_recipient@example.com',
+          cc: undefined,
+          rating: 5,
+          comment: 'This is a comment!',
+        },
+      ],
+    ]);
+  });
+
+  it('does not accept a comment when commentIncluded is false', async () => {
+    const doSubmit = jest.fn();
+    const { getByRole, findByRole } = render(
+      <FeedbackButton
+        feature="test_feature"
+        recipient="test_recipient@example.com"
+        doSubmit={doSubmit}
+        commentIncluded={false}
+        commentRequired={false}
+      />
+    );
+
+    const feedbackButton = getByRole('button');
+    expect(feedbackButton.textContent).toEqual('Feedback');
+    expect(feedbackButton).toHaveClass('btn-outline-primary');
+
+    fireEvent.click(feedbackButton);
+
+    const feedbackModal = await findByRole('dialog');
+
+    const heading = within(feedbackModal).getByRole('heading', { level: 5 });
+    expect(heading.textContent).toEqual('Give Feedback');
+
+    const feedbackModalRating = within(feedbackModal).getByTestId('feedback-modal-rating');
+
+    expect(within(feedbackModalRating).queryAllByText('Not satisfied at all')).toHaveLength(1);
+    expect(within(feedbackModalRating).queryAllByText('Very satisfied')).toHaveLength(1);
+
+    const radioButtonContainers = within(feedbackModalRating).queryAllByTestId(/rating-[1-5]/);
+    expect(radioButtonContainers).toHaveLength(5);
+
+    let chosenRadioButton: HTMLElement | undefined;
+
+    [1, 2, 3, 4, 5].forEach((rating: number) => {
+      const radioButtonContainer = within(feedbackModalRating).getByTestId(`rating-${rating}`);
+      within(radioButtonContainer).getByText(rating);
+      const radioButton = within(radioButtonContainer).getByRole('radio');
+
+      expect(radioButton).toHaveAttribute('data-value', `${rating}`);
+
+      if (rating === 5) {
+        chosenRadioButton = radioButton;
+      }
+    });
+
+    fireEvent.click(chosenRadioButton!);
+
+    const commentInputs = within(feedbackModal).queryAllByPlaceholderText(
+      'Please give as much detail as you can. Thanks!'
+    );
+
+    expect(commentInputs).toHaveLength(0);
+
+    const buttonToolbar = within(feedbackModal).getByRole('toolbar');
+    within(buttonToolbar).getByText('Cancel');
+    const sendButton = within(buttonToolbar).getByText('Send');
+
+    act(() => {
+      fireEvent.click(sendButton);
+    });
+    expect(within(buttonToolbar).getAllByRole('button')[0].textContent).toEqual('Please Wait...');
+    await waitForElementToBeRemoved(feedbackModal);
+
+    expect(doSubmit.mock.calls).toEqual([
+      [
+        {
+          feature: 'test_feature',
+          recipient: 'test_recipient@example.com',
+          cc: undefined,
+          rating: 5,
+          comment: null,
+        },
+      ],
+    ]);
+  });
+
+  it('does not accept a rating when ratingIncluded is false', async () => {
+    const doSubmit = jest.fn();
+    const { getByRole, findByRole } = render(
+      <FeedbackButton
+        feature="test_feature"
+        recipient="test_recipient@example.com"
+        doSubmit={doSubmit}
+        ratingIncluded={false}
+        ratingRequired={false}
+      />
+    );
+
+    const feedbackButton = getByRole('button');
+    expect(feedbackButton.textContent).toEqual('Feedback');
+    expect(feedbackButton).toHaveClass('btn-outline-primary');
+
+    fireEvent.click(feedbackButton);
+
+    const feedbackModal = await findByRole('dialog');
+
+    const heading = within(feedbackModal).getByRole('heading', { level: 5 });
+    expect(heading.textContent).toEqual('Give Feedback');
+
+    within(feedbackModal).getByText('How could we improve the way this works for you?');
+    const commentInput = within(feedbackModal).getByPlaceholderText(
+      'Please give as much detail as you can. Thanks!'
+    );
+
+    fireEvent.change(commentInput, { target: { value: 'This is a comment!' } });
+
+    const buttonToolbar = within(feedbackModal).getByRole('toolbar');
+    within(buttonToolbar).getByText('Cancel');
+    const sendButton = within(buttonToolbar).getByText('Send');
+
+    act(() => {
+      fireEvent.click(sendButton);
+    });
+    expect(within(buttonToolbar).getAllByRole('button')[0].textContent).toEqual('Please Wait...');
+    await waitForElementToBeRemoved(feedbackModal);
+
+    expect(doSubmit.mock.calls).toEqual([
+      [
+        {
+          feature: 'test_feature',
+          recipient: 'test_recipient@example.com',
+          cc: undefined,
+          rating: null,
+          comment: 'This is a comment!',
+        },
+      ],
+    ]);
+  });
+
+  it('will not submit without comment when comment required is true', async () => {
+    const doSubmit = jest.fn();
+    const { getByRole, findByRole } = render(
+      <FeedbackButton
+        feature="test_feature"
+        recipient="test_recipient@example.com"
+        doSubmit={doSubmit}
+        ratingIncluded={false}
+        ratingRequired={false}
+      />
+    );
+
+    const feedbackButton = getByRole('button');
+    expect(feedbackButton.textContent).toEqual('Feedback');
+    expect(feedbackButton).toHaveClass('btn-outline-primary');
+
+    fireEvent.click(feedbackButton);
+
+    const feedbackModal = await findByRole('dialog');
+
+    const heading = within(feedbackModal).getByRole('heading', { level: 5 });
+    expect(heading.textContent).toEqual('Give Feedback');
+
+    within(feedbackModal).getByText('How could we improve the way this works for you?');
+    const commentInput = within(feedbackModal).getByPlaceholderText(
+      'Please give as much detail as you can. Thanks!'
+    );
+
+    fireEvent.change(commentInput, { target: { value: 'This is a comment!' } });
+
+    const buttonToolbar = within(feedbackModal).getByRole('toolbar');
+    within(buttonToolbar).getByText('Cancel');
+    const sendButton = within(buttonToolbar).getByText('Send');
+
+    act(() => {
+      fireEvent.click(sendButton);
+    });
+    expect(within(buttonToolbar).getAllByRole('button')[0].textContent).toEqual('Please Wait...');
+    await waitForElementToBeRemoved(feedbackModal);
+
+    expect(doSubmit.mock.calls).toEqual([
+      [
+        {
+          feature: 'test_feature',
+          recipient: 'test_recipient@example.com',
+          cc: undefined,
+          rating: null,
+          comment: 'This is a comment!',
+        },
+      ],
+    ]);
+  });
+});

--- a/src/components/FeedbackButton/FeedbackButton.stories.tsx
+++ b/src/components/FeedbackButton/FeedbackButton.stories.tsx
@@ -1,0 +1,65 @@
+import { action } from '@storybook/addon-actions';
+import * as knobs from '@storybook/addon-knobs';
+import React from 'react';
+import { buttonColors } from '../../tooling/colors';
+import FeedbackButton from './FeedbackButton';
+
+export default {
+  title: 'FeedbackButton',
+  component: FeedbackButton,
+};
+
+export const Default = () => (
+  <FeedbackButton
+    backdrop={knobs.boolean('backdrop', false)}
+    className={knobs.text('className', '')}
+    color={knobs.select('color', buttonColors, 'default')}
+    disabled={knobs.boolean('disabled', false)}
+    doSubmit={async () => {
+      action('doSubmit');
+    }}
+    feature={knobs.text('feature', 'default')}
+    modalTitle={knobs.text('modalTitle', 'Modal Title')}
+    outline={knobs.boolean('outline', false)}
+    recipient={knobs.text('recipient', 'recipient@example.com')}
+  />
+);
+
+export const AllProps = () => (
+  <FeedbackButton
+    backdrop={knobs.boolean('backdrop', false)}
+    block={knobs.boolean('block', false)}
+    cancelButtonText={knobs.text('cancelButtonText', 'Cancel')}
+    className={knobs.text('className', '')}
+    color={knobs.select('color', buttonColors, 'default')}
+    commentIncluded={knobs.boolean('commentIncluded', false)}
+    commentPlaceholder={knobs.text(
+      'commentPlaceholder',
+      'Please give as much detail as you can. Thanks!'
+    )}
+    commentRequired={knobs.boolean('commentRequired', false)}
+    commentSubtitle={knobs.text(
+      'commentSubtitle',
+      'How could we improve the way this works for you?'
+    )}
+    disabled={knobs.boolean('disabled', false)}
+    doSubmit={async () => {
+      action('doSubmit');
+    }}
+    feature={knobs.text('feature', 'default')}
+    highRatingText={knobs.text('highRatingText', 'Very satisfied')}
+    lowRatingText={knobs.text('lowRatingText', 'Not satisfied at all')}
+    modalTitle={knobs.text('modalTitle', 'Give Feedback')}
+    outline={knobs.boolean('outline', false)}
+    pleaseWaitButtonText={knobs.text('pleaseWaitButtonText', 'Please Wait...')}
+    ratingIncluded={knobs.boolean('ratingIncluded', false)}
+    ratingRequired={knobs.boolean('ratingRequired', false)}
+    ratingSubtitle={knobs.text(
+      'ratingSubtitle',
+      'So far, how satisfied are you with this feature?'
+    )}
+    recipient={knobs.text('recipient', 'recipient@example.com')}
+    size={knobs.select('size', ['lg', 'md', 'sm'], 'md')}
+    submitButtonText={knobs.text('submitButtonText', 'Send')}
+  />
+);

--- a/src/components/FeedbackButton/FeedbackButton.tsx
+++ b/src/components/FeedbackButton/FeedbackButton.tsx
@@ -1,0 +1,184 @@
+import React, { FC, ReactNode, useState } from 'react';
+import Button from '../Button/Button';
+import Icon from '../Icon/Icon';
+
+import FeedbackModal from './components/FeedbackModal';
+
+export interface FeedbackFormData {
+  feature: string;
+  recipient: string;
+  cc?: string[];
+  rating: number | null;
+  comment: string | null;
+}
+
+export interface FeedbackButtonProps {
+  backdrop?: boolean;
+  block?: boolean;
+  cancelButtonText?: string;
+  cc?: string[];
+  children?: ReactNode;
+  className?: string;
+  color?: string;
+  commentIncluded?: boolean;
+  commentPlaceholder?: string;
+  commentRequired?: boolean;
+  commentSubtitle?: ReactNode;
+  disabled?: boolean;
+  doSubmit: (form: FeedbackFormData) => Promise<void>;
+  feature: string;
+  highRatingText?: string;
+  lowRatingText?: string;
+  modalTitle?: ReactNode;
+  outline?: boolean;
+  pleaseWaitButtonText?: string;
+  ratingIncluded?: boolean;
+  ratingRequired?: boolean;
+  ratingSubtitle?: ReactNode;
+  recipient: string;
+  size?: string;
+  submitButtonText?: string;
+}
+
+export interface RequiredFeedbackButtonProps {
+  backdrop: boolean;
+  block?: boolean;
+  cc?: string[];
+  children?: ReactNode;
+  className?: string;
+  color: string;
+  disabled?: boolean;
+  doSubmit: (form: FeedbackFormData) => Promise<void>;
+  feature: string;
+  modalTitle?: ReactNode;
+  outline: boolean;
+  recipient: string;
+  size?: string;
+  cancelButtonText: string;
+  commentIncluded: boolean;
+  commentPlaceholder: string;
+  commentRequired: boolean;
+  commentSubtitle: ReactNode;
+  highRatingText: string;
+  lowRatingText: string;
+  pleaseWaitButtonText: string;
+  ratingIncluded: boolean;
+  ratingRequired: boolean;
+  ratingSubtitle: ReactNode;
+  submitButtonText: string;
+}
+
+const defaultProps = {
+  backdrop: false,
+  cancelButtonText: 'Cancel',
+  color: 'primary',
+  commentIncluded: true,
+  commentPlaceholder: 'Please give as much detail as you can. Thanks!',
+  commentRequired: true,
+  commentSubtitle: 'How could we improve the way this works for you?',
+  highRatingText: 'Very satisfied',
+  lowRatingText: 'Not satisfied at all',
+  modalTitle: 'Give Feedback',
+  outline: true,
+  pleaseWaitButtonText: 'Please Wait...',
+  ratingIncluded: true,
+  ratingRequired: true,
+  ratingSubtitle: 'So far, how satisfied are you with this feature?',
+  submitButtonText: 'Send',
+};
+
+const FeedbackButton: FC<FeedbackButtonProps> = ({
+  backdrop = defaultProps.backdrop,
+  block,
+  cc,
+  children,
+  className,
+  color = defaultProps.color,
+  disabled,
+  doSubmit,
+  feature,
+  modalTitle = defaultProps.modalTitle,
+  outline = defaultProps.outline,
+  recipient,
+  size,
+  cancelButtonText = defaultProps.cancelButtonText,
+  commentIncluded = defaultProps.commentIncluded,
+  commentPlaceholder = defaultProps.commentPlaceholder,
+  commentRequired = defaultProps.commentRequired,
+  commentSubtitle = defaultProps.commentSubtitle,
+  highRatingText = defaultProps.highRatingText,
+  lowRatingText = defaultProps.lowRatingText,
+  pleaseWaitButtonText = defaultProps.pleaseWaitButtonText,
+  ratingIncluded = defaultProps.ratingIncluded,
+  ratingRequired = defaultProps.ratingRequired,
+  ratingSubtitle = defaultProps.ratingSubtitle,
+  submitButtonText = defaultProps.submitButtonText,
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const onSubmitClick = async ({
+    rating,
+    comment,
+  }: {
+    rating: number | null;
+    comment: string | null;
+  }) => {
+    const form: FeedbackFormData = {
+      feature,
+      recipient,
+      cc,
+      rating,
+      comment,
+    };
+
+    try {
+      await doSubmit(form);
+    } catch (e) {
+      /* noop */
+    }
+
+    setIsOpen(false);
+  };
+
+  return (
+    <>
+      <Button
+        block={block}
+        disabled={disabled}
+        size={size}
+        className={className}
+        outline={outline}
+        onClick={() => setIsOpen(true)}
+        color={color}
+      >
+        {children || (
+          <span className="fw-bold text-uppercase">
+            <Icon name="envelope" className="me-2" />
+            Feedback
+          </span>
+        )}
+      </Button>
+      <FeedbackModal
+        isOpen={isOpen}
+        backdrop={backdrop}
+        onSubmit={onSubmitClick}
+        onCancel={() => setIsOpen(false)}
+        modalTitle={modalTitle || feature}
+        cancelButtonText={cancelButtonText}
+        commentIncluded={commentIncluded}
+        commentPlaceholder={commentPlaceholder}
+        commentRequired={commentRequired}
+        commentSubtitle={commentSubtitle}
+        highRatingText={highRatingText}
+        lowRatingText={lowRatingText}
+        pleaseWaitButtonText={pleaseWaitButtonText}
+        ratingIncluded={ratingIncluded}
+        ratingRequired={ratingRequired}
+        ratingSubtitle={ratingSubtitle}
+        submitButtonText={submitButtonText}
+      />
+    </>
+  );
+};
+
+export default FeedbackButton;

--- a/src/components/FeedbackButton/components/FeedbackModal.tsx
+++ b/src/components/FeedbackButton/components/FeedbackModal.tsx
@@ -1,0 +1,132 @@
+import React, { FC, ReactNode, useEffect, useState } from 'react';
+import { usePrevious } from 'react-use';
+import Button from '../../Button/Button';
+import ButtonToolbar from '../../Button/ButtonToolbar';
+import Modal from '../../Modal/Modal';
+import ModalBody from '../../Modal/ModalBody';
+import ModalFooter from '../../Modal/ModalFooter';
+import ModalHeader from '../../Modal/ModalHeader';
+import FeedbackModalBody from './FeedbackModalBody';
+
+export interface FeedbackModalProps {
+  cancelButtonText: string;
+  commentIncluded: boolean;
+  commentPlaceholder: string;
+  commentRequired: boolean;
+  commentSubtitle: ReactNode;
+  highRatingText: string;
+  isOpen: boolean;
+  lowRatingText: string;
+  modalTitle: ReactNode;
+  onCancel: () => void;
+  onSubmit: (opts: { rating: number | null; comment: string | null }) => void;
+  pleaseWaitButtonText: string;
+  ratingIncluded: boolean;
+  ratingRequired: boolean;
+  ratingSubtitle: ReactNode;
+  submitButtonText: string;
+  backdrop: boolean;
+}
+
+const FeedbackModal: FC<FeedbackModalProps> = (props: FeedbackModalProps) => {
+  const {
+    cancelButtonText,
+    commentIncluded,
+    commentPlaceholder,
+    commentRequired,
+    commentSubtitle,
+    highRatingText,
+    isOpen,
+    lowRatingText,
+    modalTitle,
+    onCancel,
+    onSubmit,
+    pleaseWaitButtonText,
+    ratingIncluded,
+    ratingRequired,
+    ratingSubtitle,
+    submitButtonText,
+    ...otherProps
+  } = props;
+
+  const wasOpen = usePrevious(isOpen);
+
+  const [rating, setRating] = useState<number | null>(null);
+  const [comment, setComment] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState<boolean>(false);
+  const [ratingValidationError, setRatingValidationError] = useState<string | null>(null);
+  const [commentValidationError, setCommentValidationError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (wasOpen && !isOpen) {
+      setRatingValidationError(null);
+      setCommentValidationError(null);
+      setSubmitting(false);
+    }
+  }, [isOpen, wasOpen]);
+
+  const cancel = () => {
+    onCancel();
+    setRating(null);
+    setComment(null);
+  };
+
+  const submit = () => {
+    let error = false;
+    let commentErrorMessage = null;
+    let ratingErrorMessage = null;
+    if (!rating && ratingRequired) {
+      ratingErrorMessage = "can't be blank";
+      error = true;
+    }
+    if (!comment && commentRequired) {
+      commentErrorMessage = "can't be blank";
+      error = true;
+    }
+
+    setRatingValidationError(ratingErrorMessage);
+    setCommentValidationError(commentErrorMessage);
+
+    if (error) {
+      return;
+    }
+
+    setSubmitting(true);
+    onSubmit({ rating, comment });
+  };
+
+  return (
+    <Modal isOpen={isOpen} toggle={cancel} {...otherProps}>
+      <ModalHeader toggle={cancel}>{modalTitle}</ModalHeader>
+      <ModalBody>
+        <FeedbackModalBody
+          highRatingText={highRatingText}
+          lowRatingText={lowRatingText}
+          commentIncluded={commentIncluded}
+          commentPlaceholder={commentPlaceholder}
+          commentRequired={commentRequired}
+          commentSubtitle={commentSubtitle}
+          commentValidationError={commentValidationError}
+          ratingIncluded={ratingIncluded}
+          ratingRequired={ratingRequired}
+          ratingSubtitle={ratingSubtitle}
+          ratingValidationError={ratingValidationError}
+          setRating={setRating}
+          setComment={setComment}
+        />
+      </ModalBody>
+      <ModalFooter>
+        <ButtonToolbar>
+          <Button disabled={submitting} color="primary" onClick={submit}>
+            {submitting ? pleaseWaitButtonText : submitButtonText}
+          </Button>
+          <Button disabled={submitting} onClick={cancel}>
+            {cancelButtonText}
+          </Button>
+        </ButtonToolbar>
+      </ModalFooter>
+    </Modal>
+  );
+};
+
+export default FeedbackModal;

--- a/src/components/FeedbackButton/components/FeedbackModalBody.tsx
+++ b/src/components/FeedbackButton/components/FeedbackModalBody.tsx
@@ -1,0 +1,75 @@
+import classnames from 'classnames';
+import React, { FC, ReactNode } from 'react';
+import Input from '../../Input/Input';
+import FeedbackModalRating from './FeedbackModalRating';
+import FeedbackModalSubtitle from './FeedbackModalSubtitle';
+
+interface FeedbackModalBodyProps {
+  highRatingText: string;
+  lowRatingText: string;
+  commentIncluded: boolean;
+  commentPlaceholder: string;
+  commentRequired: boolean;
+  commentSubtitle: ReactNode;
+  commentValidationError: string | null;
+  ratingIncluded: boolean;
+  ratingRequired: boolean;
+  ratingSubtitle: ReactNode;
+  ratingValidationError: string | null;
+  setRating(rating: number): void;
+  setComment(comment: string): void;
+}
+
+const FeedbackModalBody: FC<FeedbackModalBodyProps> = ({
+  commentIncluded,
+  commentPlaceholder,
+  commentRequired,
+  commentSubtitle,
+  commentValidationError,
+  highRatingText,
+  lowRatingText,
+  ratingIncluded,
+  ratingRequired,
+  ratingSubtitle,
+  ratingValidationError,
+  setRating,
+  setComment,
+}) => (
+  <div>
+    <FeedbackModalSubtitle
+      visible={ratingIncluded}
+      required={ratingRequired}
+      text={ratingSubtitle}
+      labelClassNames={classnames({ 'js-rating-subtitle': true, 'text-danger': ratingRequired })}
+    />
+    {ratingIncluded && (
+      <FeedbackModalRating
+        highRatingText={highRatingText}
+        lowRatingText={lowRatingText}
+        ratingValidationError={ratingValidationError}
+        setRating={setRating}
+      />
+    )}
+    <FeedbackModalSubtitle
+      visible={commentIncluded}
+      required={commentRequired}
+      text={commentSubtitle}
+      labelClassNames={classnames({
+        'js-rating-subtitle': true,
+        'text-danger': commentRequired,
+      })}
+    />
+    {commentIncluded && (
+      <Input
+        className="js-comment"
+        placeholder={commentPlaceholder}
+        rows={5}
+        type="textarea"
+        onChange={(e) => setComment(e.target.value)}
+      />
+    )}
+    <span className="text-danger">{commentValidationError}</span>
+  </div>
+);
+
+export default FeedbackModalBody;

--- a/src/components/FeedbackButton/components/FeedbackModalRating.tsx
+++ b/src/components/FeedbackButton/components/FeedbackModalRating.tsx
@@ -1,0 +1,42 @@
+import React, { FC } from 'react';
+import Input from '../../Input/Input';
+
+interface FeedbackModalRatingProps {
+  highRatingText: string;
+  lowRatingText: string;
+  ratingValidationError: string | null;
+  setRating(rating: number): void;
+}
+
+const FeedbackModalRating: FC<FeedbackModalRatingProps> = ({
+  highRatingText,
+  lowRatingText,
+  ratingValidationError,
+  setRating,
+}) => (
+  <div data-testid="feedback-modal-rating">
+    <div className="mb-5">
+      <div className="d-flex mb-2 mx-3 justify-content-between">
+        <span className="js-low-rating-text font-italic">{lowRatingText}</span>
+        <span className="js-high-rating-text font-italic">{highRatingText}</span>
+      </div>
+      <div className="d-flex justify-content-around mb-2">
+        {[1, 2, 3, 4, 5].map((rating) => (
+          <div data-testid={`rating-${rating}`} key={`rating-${rating}`}>
+            <div>{rating}</div>
+            <Input
+              className="ms-auto mt-2"
+              type="radio"
+              name="rating"
+              data-value={rating}
+              onClick={() => setRating(rating)}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+    <span className="text-danger">{ratingValidationError}</span>
+  </div>
+);
+
+export default FeedbackModalRating;

--- a/src/components/FeedbackButton/components/FeedbackModalSubtitle.tsx
+++ b/src/components/FeedbackButton/components/FeedbackModalSubtitle.tsx
@@ -1,0 +1,34 @@
+import React, { FC, ReactNode } from 'react';
+import Label from '../../Label/Label';
+
+export interface FeedbackModalSubtitleProps {
+  visible: boolean;
+  required: boolean;
+  text: ReactNode;
+  labelClassNames: string;
+}
+
+const FeedbackModalSubtitle: FC<FeedbackModalSubtitleProps> = ({
+  visible,
+  required,
+  text,
+  labelClassNames,
+}: FeedbackModalSubtitleProps) => {
+  if (!visible) {
+    return null;
+  }
+
+  const labelClass = `mb-2 fw-bold ${labelClassNames}`;
+  return (
+    <span>
+      <Label>
+        <span className={labelClass}>
+          {text}
+          {required && <span className="text-danger ps-1">*</span>}
+        </span>
+      </Label>
+    </span>
+  );
+};
+
+export default FeedbackModalSubtitle;

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,6 +69,7 @@ export { default as UncontrolledDropdown } from './components/Dropdown/Uncontrol
 export { default as ExpandableSection } from './components/ExpandableSection/ExpandableSection';
 export { default as Fade } from './components/Fade/Fade';
 export { default as FeatureBanner } from './components/FeatureBanner/FeatureBanner';
+export { default as FeedbackButton } from './components/FeedbackButton/FeedbackButton';
 export { default as FilterList } from './components/FilterList/FilterList';
 // @ts-ignore: implicitly has an 'any' type
 export { default as BoundForm } from './components/Form/BoundForm';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,10 +12,15 @@
     "noEmitOnError": true,
     "noEmit": true,
     "strict": true,
-    "target": "ESNext"
+    "target": "ESNext",
+    "skipLibCheck": true
+
   },
   "include": [
     "src",
     "./tooling/helpers.ts"
+  ],
+  "exclude": [
+    "node_modules"
   ]
 }


### PR DESCRIPTION
The react-apm feedback button contains assumptions about being called
from a property front end. This makes it so that it is not useful for
BFF use cases. This commit introduces a new FeedbackButton component
that includes all the functionality from the react-apm component except
for the default onSubmit actions. Instead the submit is performed via
the doSubmit callback property. This way BFF (and other) clients can use
the same feedback button experience but provide an alternate API
endpoint.