### PR TITLE
feat: add `dismissible` to `Alert` props type

### DIFF
--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -13,6 +13,7 @@ const ICON_MAP: { [key: string]: string } = {
 
 type Props = {
   icon?: boolean;
+  dismissible?: boolean;
   onToggle?: (open: boolean) => void;
 } & AlertProps;
 


### PR DESCRIPTION
`dismissible` is not defined in `Alert` props.

![Screen Shot 2022-04-26 at 2 56 56 PM](https://user-images.githubusercontent.com/21322866/165399161-ca1fc644-8e7e-40fd-a78b-2302016b0730.png)
