### PR TITLE
fix: remove named types as it is a breaking change

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,4 +1,4 @@
-import { type Config } from '@jest/types';
+import { Config } from '@jest/types';
 
 const config: Config.InitialOptions = {
   moduleNameMapper: {

--- a/src/components/Activity/Activity.tsx
+++ b/src/components/Activity/Activity.tsx
@@ -1,6 +1,6 @@
 import fecha from 'fecha';
-import React, { type FC, type ReactNode } from 'react';
-import { type ListGroupItemProps } from 'reactstrap';
+import React, { FC, ReactNode } from 'react';
+import { ListGroupItemProps } from 'reactstrap';
 import Col from '../Layout/Col';
 import Row from '../Layout/Row';
 import ListGroupItem from '../List/ListGroupItem';

--- a/src/components/Activity/ActivityLog.tsx
+++ b/src/components/Activity/ActivityLog.tsx
@@ -1,5 +1,5 @@
-import React, { type FC } from 'react';
-import { ListGroup, type ListGroupProps } from 'reactstrap';
+import React, { FC } from 'react';
+import { ListGroup, ListGroupProps } from 'reactstrap';
 
 /**
  * Extension to Bootstrap [ListGroup](https://getbootstrap.com/docs/4.3/components/list-group/)

--- a/src/components/Address/AddressInput.tsx
+++ b/src/components/Address/AddressInput.tsx
@@ -1,7 +1,7 @@
 import classnames from 'classnames';
 import flow from 'lodash.flow';
 import noop from 'lodash.noop';
-import React, { useCallback, type ChangeEvent } from 'react';
+import React, { useCallback, ChangeEvent } from 'react';
 import FormLabelGroup from '../Form/FormLabelGroup';
 import Input from '../Input/Input';
 import Col from '../Layout/Col';

--- a/src/components/Address/CountryInput.tsx
+++ b/src/components/Address/CountryInput.tsx
@@ -1,7 +1,7 @@
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
-import React, { type FC } from 'react';
-import { type InputProps } from 'reactstrap';
+import React, { FC } from 'react';
+import { InputProps } from 'reactstrap';
 import Input from '../Input/Input';
 import COUNTRIES from './util/Countries'; // TODO i18n country names based on locale
 

--- a/src/components/Address/InternationalAddressInput.tsx
+++ b/src/components/Address/InternationalAddressInput.tsx
@@ -4,7 +4,7 @@ import Input from '../Input/Input';
 import Col from '../Layout/Col';
 import Row from '../Layout/Row';
 import CountryInput from './CountryInput';
-import getAddressFormat, { type AddressPropType } from './util/AddressFormats';
+import getAddressFormat, { AddressPropType } from './util/AddressFormats';
 
 type InternationalAddressInputProps = {
   className?: string;

--- a/src/components/Address/StateInput.tsx
+++ b/src/components/Address/StateInput.tsx
@@ -1,7 +1,7 @@
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
-import React, { type FC } from 'react';
-import { type InputProps } from 'reactstrap';
+import React, { FC } from 'react';
+import { InputProps } from 'reactstrap';
 import Input from '../Input/Input';
 import CA from './util/CAProvinces';
 import US from './util/USStates';

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -1,5 +1,5 @@
-import React, { useState, useEffect, type FC } from 'react';
-import { Alert as AlertComponent, type AlertProps } from 'reactstrap';
+import React, { useState, useEffect, FC } from 'react';
+import { Alert as AlertComponent, AlertProps } from 'reactstrap';
 import Icon from '../Icon/Icon';
 
 const noop = () => undefined;

--- a/src/components/BlockPanel/BlockPanel.tsx
+++ b/src/components/BlockPanel/BlockPanel.tsx
@@ -1,5 +1,5 @@
 import classnames from 'classnames';
-import React, { useEffect, useState, type FC, type ReactNode } from 'react';
+import React, { useEffect, useState, FC, ReactNode } from 'react';
 import Button from '../Button/Button';
 import Card from '../Card/Card';
 import CardBody from '../Card/CardBody';

--- a/src/components/Button/Close.tsx
+++ b/src/components/Button/Close.tsx
@@ -1,4 +1,4 @@
-import React, { type FC } from 'react';
+import React, { FC } from 'react';
 
 const Close: FC<React.ComponentPropsWithoutRef<'button'>> = ({ className = '', ...props }) => (
   <button type="button" className={`btn-close ${className}`} aria-label="Close" {...props} />

--- a/src/components/Button/ConfirmationButton.tsx
+++ b/src/components/Button/ConfirmationButton.tsx
@@ -1,6 +1,6 @@
 import noop from 'lodash.noop';
-import React, { useCallback, useState, type FC, type MouseEventHandler } from 'react';
-import Button, { type ButtonProps } from './Button';
+import React, { useCallback, useState, FC, MouseEventHandler } from 'react';
+import Button, { ButtonProps } from './Button';
 
 export interface ConfirmationButtonProps extends ButtonProps {
   confirmation?: string;

--- a/src/components/Calendar/Calendar.spec.tsx
+++ b/src/components/Calendar/Calendar.spec.tsx
@@ -10,7 +10,7 @@ import startOfWeek from 'date-fns/start_of_week';
 import subDays from 'date-fns/sub_days';
 import React from 'react';
 import Calendar from './Calendar';
-import { type DayInfo } from './Calendar.types';
+import { DayInfo } from './Calendar.types';
 
 describe('<Calendar />', () => {
   it('renders correctly', () => {

--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -1,8 +1,8 @@
 import format from 'date-fns/format';
 import enLocale from 'date-fns/locale/en';
 import noop from 'lodash.noop';
-import React, { useMemo, type FC } from 'react';
-import Table, { type TableProps } from '../Table/Table';
+import React, { useMemo, FC } from 'react';
+import Table, { TableProps } from '../Table/Table';
 import Day from './components/Day';
 import { getVisibleWeeks } from './util/getVisibleWeeks';
 

--- a/src/components/Calendar/MonthCalendar.tsx
+++ b/src/components/Calendar/MonthCalendar.tsx
@@ -1,6 +1,6 @@
 import Fecha from 'fecha'; // TODO replace with date-fns/parse after v2 is released
 import noop from 'lodash.noop';
-import React, { type FC } from 'react';
+import React, { FC } from 'react';
 import Col from '../Layout/Col';
 import Row from '../Layout/Row';
 import Nav from '../Nav/Nav';

--- a/src/components/Calendar/components/Day.tsx
+++ b/src/components/Calendar/components/Day.tsx
@@ -1,8 +1,8 @@
 import classnames from 'classnames';
 import format from 'date-fns/format';
 import isToday from 'date-fns/is_today';
-import React, { type FC, type MouseEventHandler, type TdHTMLAttributes } from 'react';
-import { type DayInfo } from '../Calendar.types';
+import React, { FC, MouseEventHandler, TdHTMLAttributes } from 'react';
+import { DayInfo } from '../Calendar.types';
 
 export interface DayProps
   extends Omit<TdHTMLAttributes<HTMLTableCellElement>, 'className' | 'onClick' | 'role' | 'style'> {

--- a/src/components/Calendar/components/NavLabel.tsx
+++ b/src/components/Calendar/components/NavLabel.tsx
@@ -1,4 +1,4 @@
-import React, { type FC, type MouseEventHandler, type ReactNode } from 'react';
+import React, { FC, MouseEventHandler, ReactNode } from 'react';
 import NavItem from '../../Nav/NavItem';
 import NavLink from '../../Nav/NavLink';
 

--- a/src/components/Calendar/util/getVisibleWeeks.spec.ts
+++ b/src/components/Calendar/util/getVisibleWeeks.spec.ts
@@ -1,4 +1,4 @@
-import { getVisibleWeeks, type VisibilityInfo } from './getVisibleWeeks';
+import { getVisibleWeeks, VisibilityInfo } from './getVisibleWeeks';
 
 describe('Calendar - getVisibleWeeks', () => {
   it('can get a list of weeks with the correct visibility information', () => {

--- a/src/components/Calendar/util/getVisibleWeeks.ts
+++ b/src/components/Calendar/util/getVisibleWeeks.ts
@@ -9,7 +9,7 @@ import isToday from 'date-fns/is_today';
 import startOfDay from 'date-fns/start_of_day';
 import startOfMonth from 'date-fns/start_of_month';
 import startOfWeek from 'date-fns/start_of_week';
-import { type DayInfo } from '../Calendar.types';
+import { DayInfo } from '../Calendar.types';
 
 export interface VisibilityInfo {
   currentDate: Date;

--- a/src/components/Callout/Callout.tsx
+++ b/src/components/Callout/Callout.tsx
@@ -1,4 +1,4 @@
-import React, { type HTMLProps } from 'react';
+import React, { HTMLProps } from 'react';
 
 interface CalloutProps extends HTMLProps<HTMLDivElement> {
   children?: React.ReactNode;

--- a/src/components/Checkbox/CheckboxInput.tsx
+++ b/src/components/Checkbox/CheckboxInput.tsx
@@ -1,5 +1,5 @@
-import React, { type FC, type ReactNode } from 'react';
-import { type InputProps } from 'reactstrap';
+import React, { FC, ReactNode } from 'react';
+import { InputProps } from 'reactstrap';
 import CheckboxBooleanInput from './CheckboxBooleanInput';
 import CheckboxListInput from './CheckboxListInput';
 

--- a/src/components/ClickableContainer/ClickableContainer.tsx
+++ b/src/components/ClickableContainer/ClickableContainer.tsx
@@ -1,10 +1,5 @@
 import classnames from 'classnames';
-import React, {
-  type FC,
-  type KeyboardEvent,
-  type SyntheticEvent,
-  type HTMLAttributes,
-} from 'react';
+import React, { FC, KeyboardEvent, SyntheticEvent, HTMLAttributes } from 'react';
 
 export interface ContainerProps extends HTMLAttributes<HTMLElement> {
   className?: string;

--- a/src/components/CollapsableText/CollapsableText.tsx
+++ b/src/components/CollapsableText/CollapsableText.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import Button, { type ButtonProps } from '../Button/Button';
+import Button, { ButtonProps } from '../Button/Button';
 
 const Toggle = ({ children, ...props }: ButtonProps) => (
   <Button color="link" size="sm" className="p-0 m-0 ms-2" {...props}>

--- a/src/components/Combobox/Combobox.tsx
+++ b/src/components/Combobox/Combobox.tsx
@@ -1,7 +1,7 @@
 import equal from 'fast-deep-equal';
 import React, { useEffect, useState, useRef, useMemo } from 'react';
 import { findDOMNode } from 'react-dom';
-import { type DropdownProps, type InputProps } from 'reactstrap';
+import { DropdownProps, InputProps } from 'reactstrap';
 import Badge from '../Badge/Badge';
 import Button from '../Button/Button';
 import Dropdown from '../Dropdown/Dropdown';

--- a/src/components/Datapair/Datapair.tsx
+++ b/src/components/Datapair/Datapair.tsx
@@ -1,9 +1,11 @@
 import classnames from 'classnames';
-import React, { type FC, type ReactNode } from 'react';
-import FormLabelGroup, { type FormLabelGroupProps } from '../Form/FormLabelGroup';
+import React, { ComponentProps, FC, ReactNode } from 'react';
+import FormLabelGroup from '../Form/FormLabelGroup';
 import Input from '../Input/Input';
 
-interface DatapairProps extends FormLabelGroupProps {
+// For some reason I was getting import errors when importing FormLabelGroupProps without `type`
+// TODO: Revert to extends FormLabelGroupProps when we support TS 4.5+
+interface DatapairProps extends ComponentProps<typeof FormLabelGroup> {
   className?: string;
   label?: ReactNode;
   value?: ReactNode;

--- a/src/components/ExpandableSection/ExpandableSection.tsx
+++ b/src/components/ExpandableSection/ExpandableSection.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, type FC } from 'react';
+import React, { useState, useEffect, FC } from 'react';
 import ClickableContainer from '../ClickableContainer/ClickableContainer';
 import Collapse from '../Collapse/Collapse';
 import Icon from '../Icon/Icon';

--- a/src/components/FeatureBanner/FeatureBanner.tsx
+++ b/src/components/FeatureBanner/FeatureBanner.tsx
@@ -1,4 +1,4 @@
-import React, { type FC, type ReactNode } from 'react';
+import React, { FC, ReactNode } from 'react';
 import { Alert } from 'reactstrap';
 
 interface FeatureBannerProps {

--- a/src/components/HasManyFields/HasManyFieldsRow.tsx
+++ b/src/components/HasManyFields/HasManyFieldsRow.tsx
@@ -1,8 +1,8 @@
-import { type Placement } from '@popperjs/core';
+import { Placement } from '@popperjs/core';
 import classnames from 'classnames';
 import React, { useState } from 'react';
 import Button from '../Button/Button';
-import ConfirmationButton, { type ConfirmationButtonProps } from '../Button/ConfirmationButton';
+import ConfirmationButton, { ConfirmationButtonProps } from '../Button/ConfirmationButton';
 import Icon from '../Icon/Icon';
 import Col from '../Layout/Col';
 import Row from '../Layout/Row';

--- a/src/components/HelpBubble/HelpBubble.tsx
+++ b/src/components/HelpBubble/HelpBubble.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState, type SyntheticEvent } from 'react';
+import React, { useRef, useState, SyntheticEvent } from 'react';
 import Button from '../Button/Button';
 import Icon from '../Icon/Icon';
 import Popover from '../Popover/Popover';

--- a/src/components/Highlight/Highlight.tsx
+++ b/src/components/Highlight/Highlight.tsx
@@ -1,4 +1,4 @@
-import React, { type ReactNode } from 'react';
+import React, { ReactNode } from 'react';
 
 interface Segment {
   start: number;

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -1,5 +1,5 @@
-import React, { type FC } from 'react';
-import FontAwesomeAPM, { type FontAwesomeAPMProps } from './FontAwesomeAPM';
+import React, { FC } from 'react';
+import FontAwesomeAPM, { FontAwesomeAPMProps } from './FontAwesomeAPM';
 
 const Icon: FC<FontAwesomeAPMProps> = (props) => <FontAwesomeAPM {...props} />;
 

--- a/src/components/InfoBox/InfoBox.tsx
+++ b/src/components/InfoBox/InfoBox.tsx
@@ -1,5 +1,5 @@
 import classnames from 'classnames';
-import React, { type ReactNode } from 'react';
+import React, { ReactNode } from 'react';
 import Icon from '../Icon/Icon';
 
 interface InfoBoxProps extends Omit<React.HTMLProps<HTMLDivElement>, 'className'> {

--- a/src/components/Input/CreditCardNumber.tsx
+++ b/src/components/Input/CreditCardNumber.tsx
@@ -1,6 +1,6 @@
-import cardTypeInfo, { type CardBrand } from 'credit-card-type';
-import React, { type FC } from 'react';
-import { type InputProps } from 'reactstrap';
+import cardTypeInfo, { CardBrand } from 'credit-card-type';
+import React, { FC } from 'react';
+import { InputProps } from 'reactstrap';
 import Icon from '../Icon/Icon';
 import InputGroup from '../InputGroup/InputGroup';
 import InputGroupText from '../InputGroup/InputGroupText';

--- a/src/components/Input/CurrencyInput.tsx
+++ b/src/components/Input/CurrencyInput.tsx
@@ -1,7 +1,7 @@
 import classnames from 'classnames';
 import type IMask from 'imask';
-import React, { type FC } from 'react';
-import { IMaskInput, type IMaskInputProps } from 'react-imask';
+import React, { FC } from 'react';
+import { IMaskInput, IMaskInputProps } from 'react-imask';
 import InputGroup from '../InputGroup/InputGroup';
 import InputGroupText from '../InputGroup/InputGroupText';
 

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -1,4 +1,4 @@
-import { Input, type InputProps } from 'reactstrap';
+import { Input, InputProps } from 'reactstrap';
 import type MixinPropTypes from '../../util/propTypeHelpers';
 
 export default Input as MixinPropTypes<typeof Input, InputProps>;

--- a/src/components/Input/MaskedInput.tsx
+++ b/src/components/Input/MaskedInput.tsx
@@ -1,5 +1,5 @@
-import React, { type FC } from 'react';
-import MaskedInputBase, { type MaskedInputProps } from 'react-text-mask';
+import React, { FC } from 'react';
+import MaskedInputBase, { MaskedInputProps } from 'react-text-mask';
 
 const MaskedInput: FC<MaskedInputProps> = ({ guide = false, ...props }) => (
   <MaskedInputBase className="form-control" guide={guide} {...props} />

--- a/src/components/Input/StaticInput.tsx
+++ b/src/components/Input/StaticInput.tsx
@@ -1,5 +1,5 @@
-import React, { type FC } from 'react';
-import { type InputProps } from 'reactstrap';
+import React, { FC } from 'react';
+import { InputProps } from 'reactstrap';
 import Input from './Input';
 
 export interface StaticInputProps extends InputProps {

--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -1,7 +1,7 @@
 import uniqueId from 'lodash.uniqueid';
 import PropTypes from 'prop-types';
 import React, { useEffect, useRef, useState } from 'react';
-import { type ListGroupProps } from 'reactstrap';
+import { ListGroupProps } from 'reactstrap';
 import useDeepCompareEffect from 'use-deep-compare-effect';
 import useMap from '../../hooks/useMap';
 import Input from '../Input/Input';
@@ -10,9 +10,9 @@ import Row from '../Layout/Row';
 import ScrollContainer from '../ScrollContainer/ScrollContainer';
 import ListGroup from './ListGroup';
 import ListGroupItem from './ListGroupItem';
-import ListItem, { type ListItemProps } from './ListItem';
-import FilterHeader, { type FilterHeaderProps } from './components/FilterHeader';
-import SortHeader, { type SortHeaderProps } from './components/SortHeader';
+import ListItem, { ListItemProps } from './ListItem';
+import FilterHeader, { FilterHeaderProps } from './components/FilterHeader';
+import SortHeader, { SortHeaderProps } from './components/SortHeader';
 
 interface Sort {
   property?: string | string[];

--- a/src/components/List/ListGroup.tsx
+++ b/src/components/List/ListGroup.tsx
@@ -1,6 +1,6 @@
 import classnames from 'classnames';
-import React, { type FC } from 'react';
-import { ListGroup as ListGroupComponent, type ListGroupProps } from 'reactstrap';
+import React, { FC } from 'react';
+import { ListGroup as ListGroupComponent, ListGroupProps } from 'reactstrap';
 
 type Props = {
   striped?: boolean;

--- a/src/components/List/ListItem.tsx
+++ b/src/components/List/ListItem.tsx
@@ -1,7 +1,7 @@
 import classnames from 'classnames';
 import uniqueId from 'lodash.uniqueid';
 import React, { useState } from 'react';
-import { type ListGroupItemProps } from 'reactstrap';
+import { ListGroupItemProps } from 'reactstrap';
 import Button from '../Button/Button';
 import Collapse from '../Collapse/Collapse';
 import Icon from '../Icon/Icon';

--- a/src/components/List/SortableList.tsx
+++ b/src/components/List/SortableList.tsx
@@ -1,7 +1,7 @@
 import orderBy from 'lodash.orderby';
 import PropTypes from 'prop-types';
 import React, { useState, useEffect } from 'react';
-import List, { type ListProps } from './List';
+import List, { ListProps } from './List';
 
 export interface SortableListProps<T> extends Omit<ListProps<T>, 'onFilter'> {
   filterBy: string; // initial filter value

--- a/src/components/Note/DeletedNote.tsx
+++ b/src/components/Note/DeletedNote.tsx
@@ -1,7 +1,7 @@
-import React, { type FC } from 'react';
+import React, { FC } from 'react';
 import Alert from '../Alert/Alert';
 import Button from '../Button/Button';
-import { type Note } from './Note.types';
+import { Note } from './Note.types';
 
 type DeletedNoteProps = {
   className?: string;

--- a/src/components/Note/EditableNote.tsx
+++ b/src/components/Note/EditableNote.tsx
@@ -1,11 +1,11 @@
-import React, { type FC } from 'react';
+import React, { FC } from 'react';
 import Button from '../Button/Button';
 import ButtonToolbar from '../Button/ButtonToolbar';
 import Card from '../Card/Card';
 import CardBody from '../Card/CardBody';
 import FormLabelGroup from '../Form/FormLabelGroup';
 import Input from '../Input/Input';
-import { type Note } from './Note.types';
+import { Note } from './Note.types';
 import NoteHeader from './NoteHeader';
 
 type EditableNoteProps = {

--- a/src/components/Note/Note.tsx
+++ b/src/components/Note/Note.tsx
@@ -1,10 +1,10 @@
-import React, { type FC } from 'react';
+import React, { FC } from 'react';
 import Card from '../Card/Card';
 import CardBody from '../Card/CardBody';
 import CardText from '../Card/CardText';
 import DeletedNote from './DeletedNote';
 import EditableNote, { EditableNoteDefaultProps } from './EditableNote';
-import { type Note as NoteType } from './Note.types';
+import { Note as NoteType } from './Note.types';
 import NoteHeader from './NoteHeader';
 
 type NoteProps = {

--- a/src/components/Note/NoteHeader.tsx
+++ b/src/components/Note/NoteHeader.tsx
@@ -1,11 +1,11 @@
 import classnames from 'classnames';
 import fecha from 'fecha';
-import React, { type FC } from 'react';
+import React, { FC } from 'react';
 import Badge from '../Badge/Badge';
 import Button from '../Button/Button';
 import CardHeader from '../Card/CardHeader';
 import CardTitle from '../Card/CardTitle';
-import { type Note } from './Note.types';
+import { Note } from './Note.types';
 
 // TODO extract to date helper, i18n:
 const format = (date: Date | number, dateFormat: string) => fecha.format(date, dateFormat);

--- a/src/components/Note/Notes.tsx
+++ b/src/components/Note/Notes.tsx
@@ -1,6 +1,6 @@
-import React, { type FC } from 'react';
+import React, { FC } from 'react';
 import Note from './Note';
-import { type Note as NoteType } from './Note.types';
+import { Note as NoteType } from './Note.types';
 
 type NotesProps = {
   children?: React.ReactNode;

--- a/src/components/Pagination/Paginator.tsx
+++ b/src/components/Pagination/Paginator.tsx
@@ -1,6 +1,6 @@
 import range from 'lodash.range';
 import PropTypes from 'prop-types';
-import React, { type FC } from 'react';
+import React, { FC } from 'react';
 import Icon from '../Icon/Icon';
 import Pagination from './Pagination';
 import Page from './components/Page';

--- a/src/components/Pagination/components/Page.tsx
+++ b/src/components/Pagination/components/Page.tsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { type FC } from 'react';
+import React, { FC } from 'react';
 import PaginationItem from '../PaginationItem';
 import PaginationLink from '../PaginationLink';
 

--- a/src/components/Pagination/components/ShortcutLink.tsx
+++ b/src/components/Pagination/components/ShortcutLink.tsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { type FC } from 'react';
+import React, { FC } from 'react';
 import PaginationItem from '../PaginationItem';
 import PaginationLink from '../PaginationLink';
 

--- a/src/components/Pagination/components/Summary.tsx
+++ b/src/components/Pagination/components/Summary.tsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { type FC } from 'react';
+import React, { FC } from 'react';
 
 type SummaryProps = {
   className?: string;

--- a/src/components/Placeholder/Placeholder.tsx
+++ b/src/components/Placeholder/Placeholder.tsx
@@ -1,5 +1,5 @@
 import classnames from 'classnames';
-import React, { useMemo, type HTMLProps } from 'react';
+import React, { useMemo, HTMLProps } from 'react';
 import range from '../../util/range';
 
 interface PlaceholderProps extends Omit<HTMLProps<HTMLDivElement>, 'size'> {

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -1,5 +1,5 @@
-import React, { type FC } from 'react';
-import { Popover as PopoverInternal, type PopoverProps } from 'reactstrap';
+import React, { FC } from 'react';
+import { Popover as PopoverInternal, PopoverProps } from 'reactstrap';
 
 const Popover: FC<PopoverProps> = ({ fade = false, trigger = 'legacy', ...props }) => (
   <PopoverInternal fade={fade} trigger={trigger} {...props} />

--- a/src/components/Popover/PopoverHeader.tsx
+++ b/src/components/Popover/PopoverHeader.tsx
@@ -1,5 +1,5 @@
-import React, { type FC } from 'react';
-import { type PopoverHeaderProps, PopoverHeader as InternalPopoverHeader } from 'reactstrap';
+import React, { FC } from 'react';
+import { PopoverHeaderProps, PopoverHeader as InternalPopoverHeader } from 'reactstrap';
 
 const PopoverHeader: FC<PopoverHeaderProps> = ({ tag = 'h4', ...props }) => (
   <InternalPopoverHeader tag={tag} {...props} />

--- a/src/components/Radio/RadioInput.tsx
+++ b/src/components/Radio/RadioInput.tsx
@@ -1,4 +1,4 @@
-import React, { type FC } from 'react';
+import React, { FC } from 'react';
 
 type RadioInputProps = {
   type?: any;

--- a/src/components/Spinner/ApmSpinner.tsx
+++ b/src/components/Spinner/ApmSpinner.tsx
@@ -1,4 +1,4 @@
-import React, { type FC } from 'react';
+import React, { FC } from 'react';
 import range from '../../util/range';
 
 // const since these don't behave well as live props, some animation issues:

--- a/src/components/Status/Status.tsx
+++ b/src/components/Status/Status.tsx
@@ -1,6 +1,6 @@
 import classnames from 'classnames';
 import React from 'react';
-import { type FontAwesomeAPMProps } from '../Icon/FontAwesomeAPM';
+import { FontAwesomeAPMProps } from '../Icon/FontAwesomeAPM';
 import Icon from '../Icon/Icon';
 
 interface StatusProps extends Omit<FontAwesomeAPMProps, 'name'> {

--- a/src/components/SummaryBox/SummaryBox.tsx
+++ b/src/components/SummaryBox/SummaryBox.tsx
@@ -1,5 +1,5 @@
-import React, { type FC, type ReactNode } from 'react';
-import { type CardGroupProps } from 'reactstrap';
+import React, { FC, ReactNode } from 'react';
+import { CardGroupProps } from 'reactstrap';
 import CardGroup from '../Card/CardGroup';
 import SummaryBoxItem from './SummaryBoxItem';
 

--- a/src/components/SummaryBox/SummaryBoxItem.tsx
+++ b/src/components/SummaryBox/SummaryBoxItem.tsx
@@ -1,6 +1,6 @@
 import classnames from 'classnames';
-import React, { type FC } from 'react';
-import { type CardProps } from 'reactstrap';
+import React, { FC } from 'react';
+import { CardProps } from 'reactstrap';
 import Card from '../Card/Card';
 import CardBody from '../Card/CardBody';
 

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -1,5 +1,5 @@
-import React, { type FC } from 'react';
-import { type TableProps as ReactStrapTableProps, Table as TableComponent } from 'reactstrap';
+import React, { FC } from 'react';
+import { TableProps as ReactStrapTableProps, Table as TableComponent } from 'reactstrap';
 
 export interface TableProps extends ReactStrapTableProps {
   size?: string;

--- a/src/components/Table/components/Header.tsx
+++ b/src/components/Table/components/Header.tsx
@@ -1,4 +1,4 @@
-import React, { type MouseEvent, type ReactNode } from 'react';
+import React, { MouseEvent, ReactNode } from 'react';
 import Icon from '../../Icon/Icon';
 
 export interface HeaderProps {

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -1,5 +1,5 @@
-import React, { useCallback, useState, type FC } from 'react';
-import { type TooltipProps as InnerTooltipProps, Tooltip as InnerTooltip } from 'reactstrap';
+import React, { useCallback, useState, FC } from 'react';
+import { TooltipProps as InnerTooltipProps, Tooltip as InnerTooltip } from 'reactstrap';
 
 export interface TooltipProps extends Omit<InnerTooltipProps, 'toggle'> {}
 

--- a/src/components/Tooltip/TooltipButton.tsx
+++ b/src/components/Tooltip/TooltipButton.tsx
@@ -1,8 +1,8 @@
-import { type Placement } from '@popperjs/core';
+import { Placement } from '@popperjs/core';
 import classnames from 'classnames';
-import React, { type FC } from 'react';
+import React, { FC } from 'react';
 import uniqid from 'uniqid';
-import Button, { type ButtonProps } from '../Button/Button';
+import Button, { ButtonProps } from '../Button/Button';
 import Tooltip from './Tooltip';
 
 interface TooltipButtonProps extends ButtonProps {

--- a/src/components/TruncatedText/TruncatedText.tsx
+++ b/src/components/TruncatedText/TruncatedText.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { type TooltipProps, type UncontrolledTooltipProps } from 'reactstrap';
+import { TooltipProps, UncontrolledTooltipProps } from 'reactstrap';
 import Tooltip from '../Tooltip/Tooltip';
 
 interface TruncatedTextProps {

--- a/src/components/Waiting/Waiting.tsx
+++ b/src/components/Waiting/Waiting.tsx
@@ -1,5 +1,5 @@
-import React, { type ReactNode, type FC } from 'react';
-import { type ModalProps } from 'reactstrap';
+import React, { ReactNode, FC } from 'react';
+import { ModalProps } from 'reactstrap';
 import Modal from '../Modal/Modal';
 import Spinner from '../Spinner/Spinner';
 

--- a/src/hooks/useSavedScroll.spec.ts
+++ b/src/hooks/useSavedScroll.spec.ts
@@ -1,6 +1,6 @@
 import assert from 'assert';
 import { renderHook, act } from '@testing-library/react-hooks';
-import { replaceRaf, type RafStub } from 'raf-stub';
+import { replaceRaf, RafStub } from 'raf-stub';
 import { useRef } from 'react';
 import sinon from 'sinon';
 import useSavedScroll from './useSavedScroll';

--- a/src/hooks/useSavedScroll.ts
+++ b/src/hooks/useSavedScroll.ts
@@ -1,4 +1,4 @@
-import { type RefObject, useEffect, useLayoutEffect } from 'react';
+import { RefObject, useEffect, useLayoutEffect } from 'react';
 import useScroll from 'react-use/lib/useScroll';
 import useSessionStorage from 'react-use/lib/useSessionStorage';
 import { v4 as uuidv4 } from 'uuid';

--- a/src/tooling/a11yHelpers.ts
+++ b/src/tooling/a11yHelpers.ts
@@ -1,7 +1,7 @@
 import assert from 'assert';
 import { render } from '@testing-library/react';
 import axe from 'axe-core';
-import { type ReactElement } from 'react';
+import { ReactElement } from 'react';
 
 export async function assertAccessibleContainer(container: axe.ElementContext) {
   const { violations } = await axe.run(container);


### PR DESCRIPTION
named types are only supported on typescript 4.5 and up

https://devblogs.microsoft.com/typescript/announcing-typescript-4-5/#type-on-import-names