### PR TITLE
Replace uniqid dependency with own module

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+nodejs lts-erbium

--- a/package-lock.json
+++ b/package-lock.json
@@ -26144,11 +26144,6 @@
       "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
       "dev": true
     },
-    "uniqid": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/uniqid/-/uniqid-5.2.0.tgz",
-      "integrity": "sha512-LH8zsvwJ/GL6YtNfSOmMCrI9piraAUjBfw2MCvleNE6a4pVKJwXjG2+HWhkVeFcSg+nmaPKbMrMOoxwQluZ1Mg=="
-    },
     "unique-filename": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "reactstrap": "^9.0.1",
     "styled-jsx": "^3.3.2",
     "text-mask-addons": "^3.8.0",
-    "uniqid": "^5.2.0",
     "use-deep-compare-effect": "^1.8.1",
     "use-local-storage-state": "^4.0.0",
     "uuid": "^8.3.1"

--- a/src/components/Tooltip/TooltipButton.tsx
+++ b/src/components/Tooltip/TooltipButton.tsx
@@ -1,7 +1,7 @@
 import { Placement } from '@popperjs/core';
 import classnames from 'classnames';
 import React, { FC } from 'react';
-import uniqid from 'uniqid';
+
 import Button, { ButtonProps } from '../Button/Button';
 import Tooltip from './Tooltip';
 
@@ -11,6 +11,9 @@ interface TooltipButtonProps extends ButtonProps {
   gearsBtnContainerClass?: string;
 }
 
+let count = 0;
+const getID = () => `tooltip-button-${count++}`;
+
 const TooltipButton: FC<TooltipButtonProps> = ({
   tooltip,
   disabled = false,
@@ -19,7 +22,7 @@ const TooltipButton: FC<TooltipButtonProps> = ({
   gearsBtnContainerClass,
   ...props
 }) => {
-  const buttonIdRef = React.useRef(`tooltip-button-${uniqid()}`);
+  const buttonIdRef = React.useRef(`tooltip-button-${getID()}`);
   const buttonId = buttonIdRef.current;
   const tooltipId = `tooltip-for-${buttonId}`;
   const className = classnames('d-inline-block', gearsBtnContainerClass);


### PR DESCRIPTION
uniqid tries to require node-specific modules to allow better random
strings in environments that allow access to hardware information.
These includes require additional mocking/configuration for consumers of
react-gears without any benefit, because react-gears runs on the client.
