### PR TITLE
feat: add collapse class name to block panel

### DIFF
--- a/src/components/BlockPanel/BlockPanel.tsx
+++ b/src/components/BlockPanel/BlockPanel.tsx
@@ -47,6 +47,7 @@ export interface BlockPanelProps {
   title: ReactNode;
   stickyId?: string;
   bodyClassName?: string;
+  collapseClassName?: string;
 }
 
 const defaultProps = {
@@ -73,6 +74,7 @@ const BlockPanel: FC<BlockPanelProps> = ({
   title,
   stickyId,
   bodyClassName,
+  collapseClassName,
   ...props
 }: BlockPanelProps) => {
   const useIsOpen = createIsOpenHook(stickyId, open);
@@ -154,7 +156,7 @@ const BlockPanel: FC<BlockPanelProps> = ({
         </div>
       </CardHeader>
       {children && (
-        <Collapse isOpen={children ? !expandable || isOpen : false} onExited={() => onClosed()}>
+        <Collapse className={collapseClassName} isOpen={children ? !expandable || isOpen : false} onExited={() => onClosed()}>
           {(!expandable || hideOnToggle || !collapsed) && (
             <CardBody className={bodyClassName}>{children}</CardBody>
           )}

--- a/src/components/Card/Card.stories.js
+++ b/src/components/Card/Card.stories.js
@@ -1,6 +1,8 @@
 import { text, boolean } from '@storybook/addon-knobs';
 import React from 'react';
+import { Button } from 'reactstrap';
 import { colors } from '../../tooling/colors';
+import Alert from '../Alert/Alert';
 import Card from './Card';
 import CardBody from './CardBody';
 import CardFooter from './CardFooter';
@@ -11,6 +13,22 @@ export default {
   title: 'Card',
   component: Card,
 };
+
+export const MyExample = () => {
+  return (
+    <Card>
+      <CardHeader>
+        <Button color="danger" className="float-end" onClick={() => undefined}>Delete</Button>
+        <CardTitle>Edit Application</CardTitle>
+        {/* <ErrorMessage message={this.state.error} /> */}
+      </CardHeader>
+      <CardBody>
+        {true && <Alert dismissible color="success">Application Saved</Alert>}
+        <div>Stub</div>
+      </CardBody>
+    </Card>
+  );
+}
 
 export const LiveExample = () => {
   const outline = boolean('outline', false);


### PR DESCRIPTION
The above changes are to adjust the area within the block panel that is guarded by the Collapse component.
<img width="766" alt="image" src="https://user-images.githubusercontent.com/5122541/178602537-baae18ab-0b44-43ba-9039-3c609f82e6e3.png">
