### PR TITLE
Add option to center years on MonthInput and MonthCalendar

### DIFF
--- a/src/components/Calendar/MonthCalendar.spec.tsx
+++ b/src/components/Calendar/MonthCalendar.spec.tsx
@@ -33,6 +33,32 @@ describe('<MonthCalendar />', () => {
     expect(selectedYear.classList.contains('active')).toBe(true);
   });
 
+  it('renders a range of 12 years before today date by default', () => {
+    const { getAllByTestId } = render(<MonthCalendar />);
+
+    const all = getAllByTestId('monthcalendar-navitem');
+    const years = all.slice(12);
+    const date = new Date();
+
+    years.reverse().forEach((item, index) => {
+      const year = date.getFullYear() - index;
+      expect(item.textContent).toBe(year.toString());
+    });
+  });
+
+  it('centers a range of 6 +/- years before today date if centerYearSelection', () => {
+    const { getAllByTestId } = render(<MonthCalendar centerYearSelection />);
+
+    const all = getAllByTestId('monthcalendar-navitem');
+    const years = all.slice(12);
+    const date = new Date();
+
+    years.reverse().forEach((item, index) => {
+      const year = date.getFullYear() + 6 - index;
+      expect(item.textContent).toBe(year.toString());
+    });
+  });
+
   it('calls onSelect after clicking a date', () => {
     const selectedDate = new Date(1992, 10, 30);
     const selectSpy = jest.fn();

--- a/src/components/Calendar/MonthCalendar.stories.tsx
+++ b/src/components/Calendar/MonthCalendar.stories.tsx
@@ -1,5 +1,5 @@
 import { action } from '@storybook/addon-actions';
-import { select } from '@storybook/addon-knobs';
+import { boolean, select } from '@storybook/addon-knobs';
 import React, { useState } from 'react';
 import MonthCalendar from './MonthCalendar';
 
@@ -17,6 +17,7 @@ export const MonthCalendarExample = () => {
         setDate(e);
         action('onSelect')(e);
       }}
+      centerYearSelection={boolean('Center Year Selection', false)}
       monthFormat={select('Month Format', ['M', 'MM', 'MMM', 'MMMM'], 'MMM')}
       yearFormat={select('Year Format', ['YY', 'YYYY'], 'YYYY')}
     />

--- a/src/components/Calendar/MonthCalendar.tsx
+++ b/src/components/Calendar/MonthCalendar.tsx
@@ -10,6 +10,7 @@ import { getMonths, getYears } from './util/dateRanges';
 export interface MonthCalendarProps {
   date?: Date;
   dateVisible?: (date: Date) => boolean;
+  centerYearSelection?: boolean;
   monthFormat?: string;
   yearFormat?: string;
   onSelect?: (date: Date) => void;
@@ -18,6 +19,7 @@ export interface MonthCalendarProps {
 const { format } = Fecha;
 
 const defaultProps = {
+  centerYearSelection: false,
   date: new Date(),
   dateVisible: () => true,
   monthFormat: 'MMM',
@@ -28,6 +30,7 @@ const defaultProps = {
 const MonthCalendar: FC<MonthCalendarProps> = ({
   date = defaultProps.date,
   dateVisible = defaultProps.dateVisible,
+  centerYearSelection = defaultProps.centerYearSelection,
   monthFormat = defaultProps.monthFormat,
   onSelect = defaultProps.onSelect,
   yearFormat = defaultProps.yearFormat,
@@ -51,7 +54,7 @@ const MonthCalendar: FC<MonthCalendarProps> = ({
 
         <Col className="border-start">
           <Nav pills className="d-block p-1 m-0" style={{ columnCount: 2, columnGap: 0 }}>
-            {getYears(date).map((monthYear) => (
+            {getYears(date, centerYearSelection).map((monthYear) => (
               <NavLabel
                 selected={date.getFullYear() === monthYear.getFullYear()}
                 label={format(monthYear, yearFormat)}

--- a/src/components/Calendar/util/dateRanges.spec.ts
+++ b/src/components/Calendar/util/dateRanges.spec.ts
@@ -30,6 +30,21 @@ const yearArray = [
   new Date(2010, 0),
 ];
 
+const centeredYearArray = [
+  new Date(1995, 0),
+  new Date(1996, 0),
+  new Date(1997, 0),
+  new Date(1998, 0),
+  new Date(1999, 0),
+  new Date(2000, 0),
+  new Date(2001, 0),
+  new Date(2002, 0),
+  new Date(2003, 0),
+  new Date(2004, 0),
+  new Date(2005, 0),
+  new Date(2006, 0),
+];
+
 describe('Calendar - dateRanges', () => {
   describe('getMonths', () => {
     it('can get a range of months', () => {
@@ -40,6 +55,10 @@ describe('Calendar - dateRanges', () => {
   describe('getYears', () => {
     it('can get a range of years', () => {
       expect(getYears(new Date(2000, 0, 1))).toEqual(yearArray);
+    });
+
+    it('can get a centered range of years', () => {
+      expect(getYears(new Date(2000, 0, 1), true)).toEqual(centeredYearArray);
     });
   });
 });

--- a/src/components/Calendar/util/dateRanges.ts
+++ b/src/components/Calendar/util/dateRanges.ts
@@ -4,11 +4,16 @@ import range from '../../../util/range';
 export const getMonths = (date: Date) =>
   range(0, 12).map((month) => new Date(date.getFullYear(), month, 1));
 
-export const getYears = (date: Date) => {
+export const getYears = (date: Date, centerYears: boolean = false) => {
   const now = new Date();
   const currentYear = date.getFullYear();
   const month = date.getMonth();
-  const end = currentYear + mod(now.getFullYear() - currentYear, 12) + 1;
+  let end = currentYear + 1;
+  if (centerYears) {
+    end += 6;
+  } else {
+    end += mod(now.getFullYear() - currentYear, 12);
+  }
   const start = end - 12;
   return range(start, end).map((year) => new Date(year, month, 1));
 };

--- a/src/components/Input/MonthInput.d.ts
+++ b/src/components/Input/MonthInput.d.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 interface MonthInputProps {
+  centerYearSelection?: boolean;
   className?: string;
   dateVisible?: (d: Date) => boolean;
   dateFormat?: string;

--- a/src/components/Input/MonthInput.js
+++ b/src/components/Input/MonthInput.js
@@ -54,6 +54,7 @@ function parseValue(defaultValue, dateFormat, parseDate) {
 
 export default class MonthInput extends React.Component {
   static propTypes = {
+    centerYearSelection: PropTypes.bool,
     className: PropTypes.string,
     dateVisible: PropTypes.func,
     dateFormat: PropTypes.string,
@@ -75,6 +76,7 @@ export default class MonthInput extends React.Component {
   };
 
   static defaultProps = {
+    centerYearSelection: false,
     className: '',
     dateFormat: 'MMM YYYY',
     dateVisible: () => true,
@@ -244,6 +246,7 @@ export default class MonthInput extends React.Component {
 
   render() {
     const {
+      centerYearSelection,
       className,
       dateVisible,
       disabled,
@@ -335,6 +338,7 @@ export default class MonthInput extends React.Component {
             <Calendar
               date={date}
               dateVisible={dateVisible}
+              centerYearSelection={centerYearSelection}
               monthFormat={monthFormat}
               yearFormat={yearFormat}
               onSelect={this.onSelect}

--- a/src/components/Input/MonthInput.spec.js
+++ b/src/components/Input/MonthInput.spec.js
@@ -250,8 +250,10 @@ describe('<MonthInput />', () => {
     const callback = sinon.spy();
     const defaultDate = new Date(2017, 7, 14);
     const dateVisible = (date) => isSameDay(date, defaultDate);
+    const centerYearSelection = true;
     const component = mount(
       <MonthInput
+        centerYearSelection={centerYearSelection}
         defaultValue={defaultDate}
         onChange={callback}
         dateVisible={dateVisible}
@@ -264,6 +266,11 @@ describe('<MonthInput />', () => {
     it('should pass dateVisible func to Calendar component', () => {
       const calendar = component.find('MonthCalendar');
       assert.equal(calendar.props().dateVisible, dateVisible);
+    });
+
+    it('should pass centerYearSelection to Calendar component', () => {
+      const calendar = component.find('MonthCalendar');
+      assert.equal(calendar.props().centerYearSelection, centerYearSelection);
     });
 
     it('should not allow to pick invisible date', () => {

--- a/src/components/Input/MonthInput.stories.js
+++ b/src/components/Input/MonthInput.stories.js
@@ -13,6 +13,10 @@ export default {
 export const WithProps = () => (
   <div className="d-flex">
     <MonthInput
+      centerYearSelection={boolean(
+        'centerYearSelection',
+        MonthInput.defaultProps.centerYearSelection
+      )}
       dateFormat={text('dateFormat', MonthInput.defaultProps.dateFormat)}
       monthFormat={text('monthFormat', MonthInput.defaultProps.monthFormat)}
       yearFormat={text('yearFormat', MonthInput.defaultProps.yearFormat)}


### PR DESCRIPTION
If you do not pass a `value` to MonthInput, the year selector on MonthCalendar is this year through the previous 12 years. 

![image](https://user-images.githubusercontent.com/2831063/179632355-f1743cfc-fca7-420c-84fe-9ff9dec18eb3.png)

Our PM got tripped up in a demo trying to schedule something for January the following year but found the component difficult to navigate to the next year.  This PR allows users to center the years such that whatever `value` is passed in or defaulted, that year will be in the center on the available year inputs.

![image](https://user-images.githubusercontent.com/2831063/179632734-aabdb2f1-a5fd-4266-b943-1ac16269a912.png)
