### PR TITLE
feat: make MultiSelectCombobox composable, allow input of selections

### DIFF
--- a/src/components/MultiSelectCombobox/Combobox.types.ts
+++ b/src/components/MultiSelectCombobox/Combobox.types.ts
@@ -1,6 +1,12 @@
-import { ReactElement } from 'react';
-import { ComboboxItemsProps } from './ComboboxItems';
-import { ComboboxSelectionsProps } from './ComboboxSelections';
+import type { ReactElement } from 'react';
+import ComboboxItem from './ComboboxItem';
+import type { ComboboxItemsProps } from './ComboboxItems';
+import ComboboxItems from './ComboboxItems';
+import ComboboxSelection from './ComboboxSelection';
+import type { ComboboxSelectionsProps } from './ComboboxSelections';
+import ComboboxSelections from './ComboboxSelections';
+import ComboboxWrapper from './ComboboxWrapper';
+import FilteredComboboxItems from './FilteredComboboxItems';
 
 export interface ComboboxOption {
   label: string;
@@ -14,3 +20,21 @@ export type ControlledModeChildren = [
   ReactElement<ComboboxSelectionsProps>,
   ReactElement<ComboboxItemsProps>
 ];
+
+export type OptionKey = string | number;
+
+export type FilteredItemsComponent = typeof FilteredComboboxItems;
+export type ItemComponent = typeof ComboboxItem;
+export type ItemsComponent = typeof ComboboxItems;
+export type SelectionComponent = typeof ComboboxSelection;
+export type SelectionsComponent = typeof ComboboxSelections;
+export type WrapperComponent = typeof ComboboxWrapper;
+
+export interface MultiSelectComboboxComponents {
+  FilteredItems?: FilteredItemsComponent;
+  Item?: ItemComponent;
+  Items?: ItemsComponent;
+  Selection?: SelectionComponent;
+  Selections?: SelectionsComponent;
+  Wrapper?: WrapperComponent;
+}

--- a/src/components/MultiSelectCombobox/ComboboxWrapper.spec.tsx
+++ b/src/components/MultiSelectCombobox/ComboboxWrapper.spec.tsx
@@ -5,7 +5,7 @@ import ComboboxItem from './ComboboxItem';
 import ComboboxItems from './ComboboxItems';
 import ComboboxSelection from './ComboboxSelection';
 import ComboboxSelections from './ComboboxSelections';
-import ControlledMultiSelectCombobox from './ControlledMultiSelectCombobox';
+import ComboboxWrapper from './ComboboxWrapper';
 import FilteredComboboxItems from './FilteredComboboxItems';
 
 describe('<MultiSelectCombobox>', () => {
@@ -19,12 +19,12 @@ describe('<MultiSelectCombobox>', () => {
   describe('Open/close behavior', () => {
     it('has visible items when isOpen is true', async () => {
       render(
-        <ControlledMultiSelectCombobox isOpen onToggle={toggleSpy}>
+        <ComboboxWrapper isOpen onToggle={toggleSpy}>
           <ComboboxSelections />
           <ComboboxItems>
             <ComboboxItem onClick={clickSpy}>Label</ComboboxItem>
           </ComboboxItems>
-        </ControlledMultiSelectCombobox>
+        </ComboboxWrapper>
       );
 
       const itemsMenu = await screen.findByRole('menu', { name: 'Menu Items' });
@@ -33,12 +33,12 @@ describe('<MultiSelectCombobox>', () => {
 
     it('does not have visible items when isOpen is false', async () => {
       render(
-        <ControlledMultiSelectCombobox isOpen={false} onToggle={toggleSpy}>
+        <ComboboxWrapper isOpen={false} onToggle={toggleSpy}>
           <ComboboxSelections />
           <ComboboxItems>
             <ComboboxItem onClick={clickSpy}>Label</ComboboxItem>
           </ComboboxItems>
-        </ControlledMultiSelectCombobox>
+        </ComboboxWrapper>
       );
 
       const menu = await screen.findByRole('menu', { hidden: true });
@@ -54,12 +54,12 @@ describe('<MultiSelectCombobox>', () => {
 
     it('can fire the onClick event', () => {
       render(
-        <ControlledMultiSelectCombobox isOpen={false} onToggle={toggleSpy}>
+        <ComboboxWrapper isOpen={false} onToggle={toggleSpy}>
           <ComboboxSelections />
           <ComboboxItems>
             <ComboboxItem onClick={clickSpy}>Label</ComboboxItem>
           </ComboboxItems>
-        </ControlledMultiSelectCombobox>
+        </ComboboxWrapper>
       );
 
       user.click(screen.getByText('Label'));
@@ -70,12 +70,12 @@ describe('<MultiSelectCombobox>', () => {
 
     it('can fire the onClick and onToggle events', () => {
       render(
-        <ControlledMultiSelectCombobox isOpen={false} onToggle={toggleSpy} closeOnSelect>
+        <ComboboxWrapper isOpen={false} onToggle={toggleSpy} closeOnSelect>
           <ComboboxSelections />
           <ComboboxItems>
             <ComboboxItem onClick={clickSpy}>Label</ComboboxItem>
           </ComboboxItems>
-        </ControlledMultiSelectCombobox>
+        </ComboboxWrapper>
       );
 
       user.click(screen.getByText('Label'));
@@ -88,12 +88,12 @@ describe('<MultiSelectCombobox>', () => {
   describe('<FilteredComboboxItems>', () => {
     it('can render the filtered combobox items container', async () => {
       render(
-        <ControlledMultiSelectCombobox isOpen onToggle={toggleSpy}>
+        <ComboboxWrapper isOpen onToggle={toggleSpy}>
           <ComboboxSelections />
           <FilteredComboboxItems filterValue="">
             <ComboboxItem onClick={clickSpy}>Label</ComboboxItem>
           </FilteredComboboxItems>
-        </ControlledMultiSelectCombobox>
+        </ComboboxWrapper>
       );
 
       await screen.findByRole('menu');
@@ -102,12 +102,12 @@ describe('<MultiSelectCombobox>', () => {
 
     it('can render the filtered combobox items container with filter text', async () => {
       render(
-        <ControlledMultiSelectCombobox isOpen onToggle={toggleSpy}>
+        <ComboboxWrapper isOpen onToggle={toggleSpy}>
           <ComboboxSelections />
           <FilteredComboboxItems filterValue="Alabama">
             <ComboboxItem onClick={clickSpy}>Label</ComboboxItem>
           </FilteredComboboxItems>
-        </ControlledMultiSelectCombobox>
+        </ComboboxWrapper>
       );
 
       await screen.findByRole('menu');
@@ -116,10 +116,10 @@ describe('<MultiSelectCombobox>', () => {
 
     it('can render the container with no children', async () => {
       render(
-        <ControlledMultiSelectCombobox isOpen onToggle={toggleSpy}>
+        <ComboboxWrapper isOpen onToggle={toggleSpy}>
           <ComboboxSelections />
           <FilteredComboboxItems filterValue="Alabama" />
-        </ControlledMultiSelectCombobox>
+        </ComboboxWrapper>
       );
 
       await screen.findByRole('menu');
@@ -128,10 +128,10 @@ describe('<MultiSelectCombobox>', () => {
 
     it('can render the no-children container with custom "no results" text', async () => {
       render(
-        <ControlledMultiSelectCombobox isOpen onToggle={toggleSpy}>
+        <ComboboxWrapper isOpen onToggle={toggleSpy}>
           <ComboboxSelections />
           <FilteredComboboxItems filterValue="Alabama" noResultsLabel="Du hast nicht" />
-        </ControlledMultiSelectCombobox>
+        </ComboboxWrapper>
       );
 
       await screen.findByRole('menu');
@@ -140,10 +140,10 @@ describe('<MultiSelectCombobox>', () => {
 
     it('can render a link to create an option', async () => {
       render(
-        <ControlledMultiSelectCombobox isOpen onToggle={toggleSpy}>
+        <ComboboxWrapper isOpen onToggle={toggleSpy}>
           <ComboboxSelections />
           <FilteredComboboxItems filterValue="Alabama" allowCreation />
-        </ControlledMultiSelectCombobox>
+        </ComboboxWrapper>
       );
 
       const createLink = await screen.findByText('Create Alabama');
@@ -153,14 +153,14 @@ describe('<MultiSelectCombobox>', () => {
     it('calls the onCreateClick event', async () => {
       const createClickSpy = jest.fn();
       render(
-        <ControlledMultiSelectCombobox isOpen onToggle={toggleSpy}>
+        <ComboboxWrapper isOpen onToggle={toggleSpy}>
           <ComboboxSelections />
           <FilteredComboboxItems
             filterValue="Alabama"
             allowCreation
             onCreateClick={createClickSpy}
           />
-        </ControlledMultiSelectCombobox>
+        </ComboboxWrapper>
       );
 
       const createLink = await screen.findByText('Create Alabama');
@@ -172,10 +172,10 @@ describe('<MultiSelectCombobox>', () => {
     it('calls the onFilterChange event', async () => {
       const filterChangeSpy = jest.fn();
       render(
-        <ControlledMultiSelectCombobox isOpen onToggle={toggleSpy}>
+        <ComboboxWrapper isOpen onToggle={toggleSpy}>
           <ComboboxSelections />
           <FilteredComboboxItems filterValue="" onFilterChange={filterChangeSpy} />
-        </ControlledMultiSelectCombobox>
+        </ComboboxWrapper>
       );
 
       await screen.findByRole('menu');
@@ -188,10 +188,10 @@ describe('<MultiSelectCombobox>', () => {
   describe('<ComboboxSelections>', () => {
     it('can render the component', () => {
       render(
-        <ControlledMultiSelectCombobox isOpen={false} onToggle={() => {}}>
+        <ComboboxWrapper isOpen={false} onToggle={() => {}}>
           <ComboboxSelections />
           <ComboboxItems />
-        </ControlledMultiSelectCombobox>
+        </ComboboxWrapper>
       );
 
       expect(screen.getByText('Click to select an option...')).toBeInTheDocument();
@@ -199,10 +199,10 @@ describe('<MultiSelectCombobox>', () => {
 
     it('can render with a custom placeholder', () => {
       render(
-        <ControlledMultiSelectCombobox isOpen={false} onToggle={() => {}}>
+        <ComboboxWrapper isOpen={false} onToggle={() => {}}>
           <ComboboxSelections placeholder="This is custom" />
           <ComboboxItems />
-        </ControlledMultiSelectCombobox>
+        </ComboboxWrapper>
       );
 
       expect(screen.getByText('This is custom')).toBeInTheDocument();
@@ -210,32 +210,86 @@ describe('<MultiSelectCombobox>', () => {
 
     it('can render existing selections', () => {
       render(
-        <ControlledMultiSelectCombobox isOpen={false} onToggle={() => {}}>
+        <ComboboxWrapper isOpen={false} onToggle={() => {}}>
           <ComboboxSelections>
             <ComboboxSelection>Label</ComboboxSelection>
             <ComboboxSelection>Label2</ComboboxSelection>
           </ComboboxSelections>
           <ComboboxItems />
-        </ControlledMultiSelectCombobox>
+        </ComboboxWrapper>
       );
 
       expect(screen.getAllByRole('listitem').length).toBe(2);
       expect(screen.getByText('Label')).toBeInTheDocument();
     });
 
-    it('can fire the onRemoveAll event', () => {
+    it('can fire the onRemoveAll event from a mouse click', () => {
       const removeAllSpy = jest.fn();
       render(
-        <ControlledMultiSelectCombobox isOpen={false} onToggle={() => {}}>
+        <ComboboxWrapper isOpen={false} onToggle={() => {}}>
           <ComboboxSelections onRemoveAll={removeAllSpy}>
             <ComboboxSelection>Label</ComboboxSelection>
           </ComboboxSelections>
           <ComboboxItems />
-        </ControlledMultiSelectCombobox>
+        </ComboboxWrapper>
       );
 
       user.click(screen.getByLabelText('Remove all selections'));
       expect(removeAllSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('can fire the onRemoveAll event when the button is focused and {enter} is typed', () => {
+      const removeAllSpy = jest.fn();
+      render(
+        <ComboboxWrapper isOpen={false} onToggle={() => {}}>
+          <ComboboxSelections onRemoveAll={removeAllSpy}>
+            <ComboboxSelection>Label</ComboboxSelection>
+          </ComboboxSelections>
+          <ComboboxItems />
+        </ComboboxWrapper>
+      );
+
+      const removeAllButton = screen.getByLabelText('Remove all selections');
+      removeAllButton.focus();
+      user.keyboard('{enter}');
+
+      expect(removeAllSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('can fire the onRemoveAll event when the button is focused and {space} is typed', () => {
+      const removeAllSpy = jest.fn();
+      render(
+        <ComboboxWrapper isOpen={false} onToggle={() => {}}>
+          <ComboboxSelections onRemoveAll={removeAllSpy}>
+            <ComboboxSelection>Label</ComboboxSelection>
+          </ComboboxSelections>
+          <ComboboxItems />
+        </ComboboxWrapper>
+      );
+
+      const removeAllButton = screen.getByLabelText('Remove all selections');
+      removeAllButton.focus();
+      user.keyboard('{space}');
+
+      expect(removeAllSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('can fire the onRemoveAll event when the button is focused and "z" is typed', () => {
+      const removeAllSpy = jest.fn();
+      render(
+        <ComboboxWrapper isOpen={false} onToggle={() => {}}>
+          <ComboboxSelections onRemoveAll={removeAllSpy}>
+            <ComboboxSelection>Label</ComboboxSelection>
+          </ComboboxSelections>
+          <ComboboxItems />
+        </ComboboxWrapper>
+      );
+
+      const removeAllButton = screen.getByLabelText('Remove all selections');
+      removeAllButton.focus();
+      user.keyboard('z');
+
+      expect(removeAllSpy).not.toHaveBeenCalled();
     });
   });
 
@@ -243,12 +297,12 @@ describe('<MultiSelectCombobox>', () => {
     it('can render the selection', () => {
       const removeSpy = jest.fn();
       render(
-        <ControlledMultiSelectCombobox isOpen={false} onToggle={() => {}}>
+        <ComboboxWrapper isOpen={false} onToggle={() => {}}>
           <ComboboxSelections>
             <ComboboxSelection onRemove={removeSpy}>Label</ComboboxSelection>
           </ComboboxSelections>
           <ComboboxItems />
-        </ControlledMultiSelectCombobox>
+        </ComboboxWrapper>
       );
 
       expect(screen.getByText('Label')).toBeInTheDocument();
@@ -257,12 +311,12 @@ describe('<MultiSelectCombobox>', () => {
     it('can call onRemove when the close button within the selection is clicked', () => {
       const removeSpy = jest.fn();
       render(
-        <ControlledMultiSelectCombobox isOpen={false} onToggle={() => {}}>
+        <ComboboxWrapper isOpen={false} onToggle={() => {}}>
           <ComboboxSelections>
             <ComboboxSelection onRemove={removeSpy}>Label</ComboboxSelection>
           </ComboboxSelections>
           <ComboboxItems />
-        </ControlledMultiSelectCombobox>
+        </ComboboxWrapper>
       );
 
       const closeButton = within(screen.getByRole('list')).getByRole('button', {
@@ -270,6 +324,63 @@ describe('<MultiSelectCombobox>', () => {
       });
       user.click(closeButton);
       expect(removeSpy).toHaveBeenCalled();
+    });
+
+    it('can call onRemove when the close button within the selection is focused and {space} is typed', () => {
+      const removeSpy = jest.fn();
+      render(
+        <ComboboxWrapper isOpen={false} onToggle={() => {}}>
+          <ComboboxSelections>
+            <ComboboxSelection onRemove={removeSpy}>Label</ComboboxSelection>
+          </ComboboxSelections>
+          <ComboboxItems />
+        </ComboboxWrapper>
+      );
+
+      const closeButton = within(screen.getByRole('list')).getByRole('button', {
+        hidden: true,
+      });
+      closeButton.focus();
+      user.keyboard('{space}');
+      expect(removeSpy).toHaveBeenCalled();
+    });
+
+    it('can call onRemove when the close button within the selection is focused and {enter} is typed', () => {
+      const removeSpy = jest.fn();
+      render(
+        <ComboboxWrapper isOpen={false} onToggle={() => {}}>
+          <ComboboxSelections>
+            <ComboboxSelection onRemove={removeSpy}>Label</ComboboxSelection>
+          </ComboboxSelections>
+          <ComboboxItems />
+        </ComboboxWrapper>
+      );
+
+      const closeButton = within(screen.getByRole('list')).getByRole('button', {
+        hidden: true,
+      });
+      closeButton.focus();
+      user.keyboard('{enter}');
+      expect(removeSpy).toHaveBeenCalled();
+    });
+
+    it('does not call onRemove when the close button within the selection is focused and "a" is typed', () => {
+      const removeSpy = jest.fn();
+      render(
+        <ComboboxWrapper isOpen={false} onToggle={() => {}}>
+          <ComboboxSelections>
+            <ComboboxSelection onRemove={removeSpy}>Label</ComboboxSelection>
+          </ComboboxSelections>
+          <ComboboxItems />
+        </ComboboxWrapper>
+      );
+
+      const closeButton = within(screen.getByRole('list')).getByRole('button', {
+        hidden: true,
+      });
+      closeButton.focus();
+      user.keyboard('a');
+      expect(removeSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/components/MultiSelectCombobox/ComboboxWrapper.tsx
+++ b/src/components/MultiSelectCombobox/ComboboxWrapper.tsx
@@ -4,19 +4,14 @@ import Dropdown from '../Dropdown/Dropdown';
 import type { ComboboxItemsProps } from './ComboboxItems';
 import type { ComboboxSelectionsProps } from './ComboboxSelections';
 
-export interface ControlledMultiSelectComboboxProps {
+export interface ComboboxWrapperProps {
   children: [ReactElement<ComboboxSelectionsProps>, ReactElement<ComboboxItemsProps>];
   closeOnSelect?: boolean;
   isOpen?: boolean;
   onToggle?: () => void;
 }
 
-const ControlledMultiSelectCombobox = ({
-  children,
-  closeOnSelect,
-  isOpen,
-  onToggle,
-}: ControlledMultiSelectComboboxProps) => {
+const ComboboxWrapper = ({ children, closeOnSelect, isOpen, onToggle }: ComboboxWrapperProps) => {
   const handleToggle: MouseEventHandler = (e) => {
     if (closeOnSelect || (e?.target as HTMLButtonElement)?.getAttribute('role') !== 'menuitem') {
       onToggle?.();
@@ -30,4 +25,4 @@ const ControlledMultiSelectCombobox = ({
   );
 };
 
-export default ControlledMultiSelectCombobox;
+export default ComboboxWrapper;

--- a/src/components/MultiSelectCombobox/MultiSelectCombobox.stories.tsx
+++ b/src/components/MultiSelectCombobox/MultiSelectCombobox.stories.tsx
@@ -3,12 +3,18 @@ import { boolean, text } from '@storybook/addon-knobs';
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
 import React from 'react';
 import { states } from '../../tooling/comboboxData';
+import DropdownItem from '../Dropdown/DropdownItem';
+import Icon from '../Icon/Icon';
+import type { ItemComponent } from './Combobox.types';
 import ComboboxItem from './ComboboxItem';
+import type { ComboboxItemProps } from './ComboboxItem';
 import ComboboxItems from './ComboboxItems';
 import ComboboxSelection from './ComboboxSelection';
 import ComboboxSelections from './ComboboxSelections';
 import FilteredComboboxItems from './FilteredComboboxItems';
 import MultiSelectCombobox from './MultiSelectCombobox';
+
+type ComboboxStory = ComponentStory<typeof MultiSelectCombobox>;
 
 export default {
   title: ' Multi-Select Combobox',
@@ -28,8 +34,9 @@ const selections = [
   { label: 'Lemur', value: 'lemur', id: 200 },
 ];
 
-export const UncontrolledMode: ComponentStory<typeof MultiSelectCombobox> = () => (
+export const UncontrolledMode: ComboboxStory = () => (
   <MultiSelectCombobox
+    initialSelections={['CA', 'AK']}
     options={states}
     onChange={action('onChange')}
     filterOptions={boolean('filterOptions', true)}
@@ -42,7 +49,7 @@ export const UncontrolledMode: ComponentStory<typeof MultiSelectCombobox> = () =
   />
 );
 
-export const LongOptionLabels: ComponentStory<typeof MultiSelectCombobox> = () => (
+export const LongOptionLabels: ComboboxStory = () => (
   <MultiSelectCombobox
     options={[
       {
@@ -66,7 +73,7 @@ export const LongOptionLabels: ComponentStory<typeof MultiSelectCombobox> = () =
   />
 );
 
-export const ControlledModeSimple: ComponentStory<typeof MultiSelectCombobox> = () => (
+export const ControlledModeSimple: ComboboxStory = () => (
   <MultiSelectCombobox isOpen={boolean('isOpen', false)} onToggle={action('onToggle')}>
     <ComboboxSelections onRemoveAll={action('onRemoveAll')}>
       {selections.map((selection) => (
@@ -85,7 +92,7 @@ export const ControlledModeSimple: ComponentStory<typeof MultiSelectCombobox> = 
   </MultiSelectCombobox>
 );
 
-export const ControlledModeWithFilter: ComponentStory<typeof MultiSelectCombobox> = () => (
+export const ControlledModeWithFilter: ComboboxStory = () => (
   <MultiSelectCombobox
     isOpen={boolean('isOpen', false)}
     onToggle={action('onToggle')}
@@ -111,4 +118,19 @@ export const ControlledModeWithFilter: ComponentStory<typeof MultiSelectCombobox
       ))}
     </FilteredComboboxItems>
   </MultiSelectCombobox>
+);
+
+const MyCustomItem: ItemComponent = ({ children, onClick }: ComboboxItemProps) => (
+  <DropdownItem onClick={onClick} className="fs-1">
+    <Icon name="award" className="me-2 text-primary" />
+    <span className="text-success">{children}</span>
+  </DropdownItem>
+);
+
+export const CustomItemRendering: ComboboxStory = () => (
+  <MultiSelectCombobox
+    onChange={action('onChange')}
+    options={states}
+    components={{ Item: MyCustomItem }}
+  />
 );

--- a/src/components/MultiSelectCombobox/MultiSelectCombobox.tsx
+++ b/src/components/MultiSelectCombobox/MultiSelectCombobox.tsx
@@ -1,14 +1,14 @@
 import React, { Children } from 'react';
 import type { ComboboxOption, ControlledModeChildren } from './Combobox.types';
-import type { ControlledMultiSelectComboboxProps } from './ControlledMultiSelectCombobox';
-import ControlledMultiSelectCombobox from './ControlledMultiSelectCombobox';
-import type { UncontrolledMultiSelectComboboxProps } from './UncontrolledMultiSelectCombobox';
+import type { ComboboxWrapperProps } from './ComboboxWrapper';
+import ComboboxWrapper from './ComboboxWrapper';
 import UncontrolledMultiSelectCombobox from './UncontrolledMultiSelectCombobox';
+import type { UncontrolledMultiSelectComboboxProps } from './UncontrolledMultiSelectCombobox';
 import checkInvariantViolations from './util/checkInvariantViolations';
 
 interface MultiSelectComboboxProps<T extends ComboboxOption>
   extends Partial<UncontrolledMultiSelectComboboxProps<T>>,
-    Partial<ControlledMultiSelectComboboxProps> {}
+    Partial<ComboboxWrapperProps> {}
 
 function MultiSelectCombobox<T extends ComboboxOption>({
   children,
@@ -32,9 +32,9 @@ function MultiSelectCombobox<T extends ComboboxOption>({
     );
   }
   return (
-    <ControlledMultiSelectCombobox isOpen={isOpen} onToggle={onToggle} {...remainingProps}>
+    <ComboboxWrapper isOpen={isOpen} onToggle={onToggle} {...remainingProps}>
       {children as ControlledModeChildren}
-    </ControlledMultiSelectCombobox>
+    </ComboboxWrapper>
   );
 }
 


### PR DESCRIPTION
- Add types entries for the composition components
- Rename `ControlledMultiSelectCombobox` to `ComboboxWrapper` to better describe its role in the composition.
- Show an example of custom Item rendering using composition in the Uncontrolled case (satisfies https://trello.com/c/IyMBLsiB)
- Add composition semantics in `UncontrolledMultiSelectCombobox` 
- Add prop to pre-select selections in `UncontrolledMultiSelectCombobox` 
- Add a few keyboard tests that were missed in the initial implementation