### PR TITLE
chore: fix recipient usage for `FeedbackButton`

### DIFF
--- a/src/components/FeedbackButton/FeedbackButton.spec.tsx
+++ b/src/components/FeedbackButton/FeedbackButton.spec.tsx
@@ -19,7 +19,7 @@ describe('<FeedbackButton />', () => {
     const { getByRole, findByRole } = render(
       <FeedbackButton
         feature="test_feature"
-        recipient="test_recipient@example.com"
+        recipient="test_team_name"
         doSubmit={doSubmit}
       />
     );
@@ -92,7 +92,7 @@ describe('<FeedbackButton />', () => {
       [
         {
           feature: 'test_feature',
-          recipient: 'test_recipient@example.com',
+          recipient: 'test_team_name',
           cc: undefined,
           rating: 5,
           comment: 'This is a comment!',
@@ -106,7 +106,7 @@ describe('<FeedbackButton />', () => {
     const { getByRole, findByRole } = render(
       <FeedbackButton
         feature="test_feature"
-        recipient="test_recipient@example.com"
+        recipient="test_team_name"
         doSubmit={doSubmit}
         backdrop
         cancelButtonText="Cancel2"
@@ -194,7 +194,7 @@ describe('<FeedbackButton />', () => {
       [
         {
           feature: 'test_feature',
-          recipient: 'test_recipient@example.com',
+          recipient: 'test_team_name',
           cc: undefined,
           rating: 5,
           comment: 'This is a comment!',
@@ -208,7 +208,7 @@ describe('<FeedbackButton />', () => {
     const { getByRole, findByRole } = render(
       <FeedbackButton
         feature="test_feature"
-        recipient="test_recipient@example.com"
+        recipient="test_team_name"
         doSubmit={doSubmit}
         commentIncluded={false}
         commentRequired={false}
@@ -270,7 +270,7 @@ describe('<FeedbackButton />', () => {
       [
         {
           feature: 'test_feature',
-          recipient: 'test_recipient@example.com',
+          recipient: 'test_team_name',
           cc: undefined,
           rating: 5,
           comment: null,
@@ -284,7 +284,7 @@ describe('<FeedbackButton />', () => {
     const { getByRole, findByRole } = render(
       <FeedbackButton
         feature="test_feature"
-        recipient="test_recipient@example.com"
+        recipient="test_team_name"
         doSubmit={doSubmit}
         ratingIncluded={false}
         ratingRequired={false}
@@ -323,7 +323,7 @@ describe('<FeedbackButton />', () => {
       [
         {
           feature: 'test_feature',
-          recipient: 'test_recipient@example.com',
+          recipient: 'test_team_name',
           cc: undefined,
           rating: null,
           comment: 'This is a comment!',
@@ -337,7 +337,7 @@ describe('<FeedbackButton />', () => {
     const { getByRole, findByRole } = render(
       <FeedbackButton
         feature="test_feature"
-        recipient="test_recipient@example.com"
+        recipient="test_team_name"
         doSubmit={doSubmit}
         ratingIncluded={false}
         ratingRequired={false}
@@ -376,7 +376,7 @@ describe('<FeedbackButton />', () => {
       [
         {
           feature: 'test_feature',
-          recipient: 'test_recipient@example.com',
+          recipient: 'test_team_name',
           cc: undefined,
           rating: null,
           comment: 'This is a comment!',

--- a/src/components/FeedbackButton/FeedbackButton.spec.tsx
+++ b/src/components/FeedbackButton/FeedbackButton.spec.tsx
@@ -17,11 +17,7 @@ describe('<FeedbackButton />', () => {
   it('submits feedback via doSubmit callback with all default properties', async () => {
     const doSubmit = jest.fn();
     const { getByRole, findByRole } = render(
-      <FeedbackButton
-        feature="test_feature"
-        recipient="test_team_name"
-        doSubmit={doSubmit}
-      />
+      <FeedbackButton feature="test_feature" recipient="test_team_name" doSubmit={doSubmit} />
     );
 
     const feedbackButton = getByRole('button');

--- a/src/components/FeedbackButton/FeedbackButton.stories.tsx
+++ b/src/components/FeedbackButton/FeedbackButton.stories.tsx
@@ -21,7 +21,7 @@ export const Default = () => (
     feature={knobs.text('feature', 'default')}
     modalTitle={knobs.text('modalTitle', 'Modal Title')}
     outline={knobs.boolean('outline', false)}
-    recipient={knobs.text('recipient', 'recipient@example.com')}
+    recipient={knobs.text('recipient', 'my_team_name')}
   />
 );
 


### PR DESCRIPTION
fixes https://appfolio.slack.com/archives/C03ADPNLQM9/p1661294497607199?thread_ts=1661288820.667249&cid=C03ADPNLQM9

`recipient` is used as `dev-feedback+#{recipient}@appfolio.com` in [/customer_feedbacks](https://qa.qa.appfolio.com/api/docs/v2#operation/postCustomerFeedbacks) endpoint.

e.g.

<img width="722" alt="Screen Shot 2022-08-23 at 3 56 46 PM" src="https://user-images.githubusercontent.com/21322866/186280284-be39b3b6-debe-4158-a762-bf5c45a7234f.png">

_source: [parterportal_app](https://github.com/appfolio/partnerportal_app/blob/2c278705a12e691a375dcc1ac2806f2f69cedd14/app/javascript/portal/src/components/PartnerFeedbackButton.js)_ 