### PR TITLE
Fix SortableList double rendering issue

### DIFF
--- a/src/components/List/SortableList.tsx
+++ b/src/components/List/SortableList.tsx
@@ -1,6 +1,6 @@
 import orderBy from 'lodash.orderby';
 import PropTypes from 'prop-types';
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import List, { ListProps } from './List';
 
 export interface SortableListProps<T> extends Omit<ListProps<T>, 'onFilter'> {
@@ -26,20 +26,15 @@ function SortableList<T>({
   const [ascending, setAscending] = useState<boolean | undefined>(
     sort.ascending === undefined ? true : sort.ascending
   );
-  const [sorted, setSorted] = useState(items);
 
-  useEffect(() => {
-    const properties = typeof sortProperty === 'string' ? [sortProperty] : sortProperty;
-    const direction = properties?.map(() => (ascending ? 'asc' : 'desc'));
+  const properties = typeof sortProperty === 'string' ? [sortProperty] : sortProperty;
+  const direction = properties?.map(() => (ascending ? 'asc' : 'desc'));
 
-    setSorted(
-      orderBy(
-        filter && onFilter ? items.filter((item: T) => onFilter(filter, item)) : items,
-        properties,
-        direction
-      )
-    );
-  }, [ascending, filter, items, onFilter, sortProperty]);
+  const itemsSorted: T[] = orderBy(
+    filter && onFilter ? items.filter((item: T) => onFilter(filter, item)) : items,
+    properties,
+    direction
+  );
 
   const handleSort = (sortBy: SortableListProps<T>['sort']) => {
     setSortProperty(sortBy?.property);
@@ -53,7 +48,7 @@ function SortableList<T>({
       onSort={sortOptions && handleSort}
       sort={{ property: sortProperty, ascending }}
       sortOptions={sortOptions}
-      items={sorted}
+      items={itemsSorted}
       flush
       scrollPositionKey={scrollPositionKey}
       {...props}


### PR DESCRIPTION
## Summary
When a `SortableList` is re-rendered, it will first render the list with the old state, then quickly get re-rendered again with the new state.

## Detail Explanation
For example, you have a list of 5 items to render and later you remove an item from the list. What will happen is as follows:
- The items count going from 5 -> 4 triggers a re-render
- However, since `SortableList` renders the `sorted` state, not `items`, it renders the list with 5 items https://github.com/appfolio/react-gears/blame/698248c089305de8a2c9cf575a9f23e16caad928/src/components/List/SortableList.tsx#L56
- The `useEffect` hook gets executed because `items` got updated https://github.com/appfolio/react-gears/blame/698248c089305de8a2c9cf575a9f23e16caad928/src/components/List/SortableList.tsx#L31
- The `sorted` gets updated by the hook with 4 items
- `SortableList` re-renders again

https://user-images.githubusercontent.com/4545184/186539095-2b2fce67-0b66-45eb-bf5f-e98831944364.mov

## Impact
This causes the UI to flicker (see the attached screen recording) and makes it buggy when you thought you were rendering the new state but in fact, you're rendering with the old state.

## Proposed Solution
Get rid of the intermediate `sorted` state and sort directly.