### PR TITLE
Swap arrow direction in List->SortHeader

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,2 @@
 nodejs lts-gallium
+yarn 1.22.19

--- a/src/components/List/List.spec.js
+++ b/src/components/List/List.spec.js
@@ -350,9 +350,11 @@ describe('<List />', () => {
           ]}
         />
       );
-
+      assert.equal(wrapper.find('.js-sort-header').find('Icon').props().name, 'arrow-up');
+      
       wrapper.find('.js-sort-header').find('button').simulate('click');
 
+      assert.equal(wrapper.find('.js-sort-header').find('Icon').props().name, 'arrow-down');
       sinon.assert.calledWithExactly(onSort, { property: 'last', ascending: false });
     });
   });

--- a/src/components/List/List.spec.js
+++ b/src/components/List/List.spec.js
@@ -351,7 +351,7 @@ describe('<List />', () => {
         />
       );
       assert.equal(wrapper.find('.js-sort-header').find('Icon').props().name, 'arrow-up');
-      
+
       wrapper.find('.js-sort-header').find('button').simulate('click');
 
       assert.equal(wrapper.find('.js-sort-header').find('Icon').props().name, 'arrow-down');

--- a/src/components/List/components/SortHeader.tsx
+++ b/src/components/List/components/SortHeader.tsx
@@ -63,7 +63,7 @@ const SortHeader = ({
           id="sort-button"
           onClick={() => onChangeAscending(!ascending)}
         >
-          <Icon name={ascending ? 'arrow-down' : 'arrow-up'} size="lg" />
+          <Icon name={ascending ? 'arrow-up' : 'arrow-down'} size="lg" />
           <span className="sr-only">Change Sort Direction</span>
         </Button>
       )}


### PR DESCRIPTION
The arrow orientation should be:
- ascending: up arrow
- descending: down arrow

This change fixes that for the List SortHeader component