### PR TITLE
Release scripts use yarn npm publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,9 +40,9 @@
     "dist:esm": "babel src --out-dir esm --config-file ./babel.esm.config.js --extensions '.js,.ts,.tsx'",
     "dist:lib": "babel src --out-dir lib --config-file ./babel.build.config.js --extensions '.js,.ts,.tsx'",
     "dist": "yarn clean && concurrently \"yarn:dist:*\"",
-    "publish:prerelease": "TAG=beta yarn publish --tag beta",
-    "publish:npm": "yarn publish --ignore-scripts --tag ${TAG:='latest'} --access public --@appfolio:registry='https://registry.npmjs.org'",
-    "publish:github": "yarn publish --ignore-scripts",
+    "publish:prerelease": "TAG=beta yarn npm publish --tag beta",
+    "publish:npm": "yarn npm publish --ignore-scripts --tag ${TAG:='latest'} --access public --@appfolio:registry='https://registry.npmjs.org'",
+    "publish:github": "yarn npm publish --ignore-scripts",
     "prepublishOnly": "yarn dist",
     "postpublish": "yarn publish:npm && git push --no-verify && git push --tags"
   },


### PR DESCRIPTION
The release failed here: https://github.com/appfolio/react-gears/runs/8026065641?check_suite_focus=true

The yarn docs say the command is `yarn npm publish`.
https://yarnpkg.com/cli/npm/publish