### PR TITLE
fix: prevent list item content from overflowing

### DIFF
--- a/src/components/List/ListItem.tsx
+++ b/src/components/List/ListItem.tsx
@@ -54,7 +54,7 @@ function ListItem<T>({
     >
       <div className="d-flex align-items-center">
         {select && (
-          <div className="pe-2">
+          <div className="pe-2" style={{ width: '26px' }}>
             <Input
               id={id}
               type={select}
@@ -70,7 +70,12 @@ function ListItem<T>({
             </Label>
           </div>
         )}
-        <div className="me-auto w-100 px-2">{render(item, selected)}</div>
+        <div
+          className="me-auto w-100 px-2"
+          style={{ maxWidth: select ? 'calc(100% - 26px)' : '100%' }}
+        >
+          {render(item, selected)}
+        </div>
         {isExpandable && (
           <Button
             color="link"


### PR DESCRIPTION
## Current
Column width is unbounded, so the row content overflows, causing columns to be misaligned and the horizontal scroll bar appearing
<img width="439" alt="Screen Shot 2022-09-23 at 1 34 06 PM" src="https://user-images.githubusercontent.com/109104908/192652070-cf11ea21-b654-4215-a7d1-7ff5ab0d197f.png">

## Fixed
Set a max-width for a div in `ListItem` containing it's content
![Screen Shot 2022-09-27 at 4 00 01 PM](https://user-images.githubusercontent.com/109104908/192652388-a590cded-f2c1-4c34-b079-4bacc562c5ea.png)
