### PR TITLE
feat: allow item to be selectable by clicking anywhere on the item

### DIFF
--- a/src/components/List/List.spec.js
+++ b/src/components/List/List.spec.js
@@ -2,6 +2,7 @@ import assert from 'assert';
 import { render } from '@testing-library/react';
 import { mount, shallow } from 'enzyme';
 import React from 'react';
+import { Label } from 'reactstrap';
 import sinon from 'sinon';
 import List from './List';
 import ListItem from './ListItem';
@@ -384,5 +385,19 @@ describe('<List />', () => {
     const wrapper = mount(<List items={items} header={header} />);
 
     assert.strictEqual(wrapper.find('.custom-header').parent().hasClass('w-100'), true);
+  });
+
+  it('should add styling to each item when selectAnywhere is true', () => {
+    const component = mount(
+      <List items={items} selectAnywhere>
+        {(item) => item}
+      </List>
+    );
+    const listItems = component.find(ListItem);
+    listItems.forEach((item) => {
+      assert.equal(item.prop('tag'), Label);
+      assert.equal(item.prop('style').cursor, 'pointer');
+      assert.equal(item.prop('style').marginBottom, 0);
+    });
   });
 });

--- a/src/components/List/List.stories.js
+++ b/src/components/List/List.stories.js
@@ -109,6 +109,7 @@ export const WithEverything = () => {
       ]}
       striped={boolean('striped', false)}
       flush={boolean('flush')}
+      selectAnywhere={boolean('selectAnywhere', false)}
     >
       {(item) => <ItemRow item={item} />}
     </List>

--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -5,6 +5,7 @@ import { ListGroupProps } from 'reactstrap';
 import useDeepCompareEffect from 'use-deep-compare-effect';
 import useMap from '../../hooks/useMap';
 import Input from '../Input/Input';
+import Label from '../Label/Label';
 import Col from '../Layout/Col';
 import Row from '../Layout/Row';
 import ScrollContainer from '../ScrollContainer/ScrollContainer';
@@ -45,6 +46,7 @@ export interface ListProps<T> extends Omit<ListGroupProps, 'onSelect'> {
   sortByLabel?: SortHeaderProps['sortByLabel'];
   sortOptions?: SortHeaderProps['sortOptions'];
   selectable?: (item: T) => boolean;
+  selectAnywhere?: boolean;
 }
 
 const defaultProps = {
@@ -58,6 +60,7 @@ const defaultProps = {
   sort: {},
   sortByLabel: 'Sort by',
   selectable: () => true,
+  selectAnywhere: false,
 };
 
 function List<T extends Item>({
@@ -81,6 +84,7 @@ function List<T extends Item>({
   sortByLabel = defaultProps.sortByLabel,
   sortOptions,
   selectable = defaultProps.selectable,
+  selectAnywhere = defaultProps.selectAnywhere,
   ...props
 }: ListProps<T>) {
   const {
@@ -160,6 +164,10 @@ function List<T extends Item>({
 
   const showHeader = header || select === 'checkbox' || select === 'switch' || onFilter || onSort;
 
+  const selectAnywhereProps = selectAnywhere
+    ? { tag: Label, style: { cursor: 'pointer', marginBottom: 0 } }
+    : {};
+
   return (
     <ListGroup flush={flush} tag="div" {...props}>
       {showHeader && (
@@ -223,6 +231,7 @@ function List<T extends Item>({
               onSelect={handleSelection}
               onExpand={onExpand}
               selectable={selectable}
+              {...selectAnywhereProps}
             >
               {render}
             </ListItem>
@@ -256,6 +265,7 @@ List.propTypes = {
   }),
   sortByLabel: PropTypes.string,
   sortOptions: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
+  selectAnywhere: PropTypes.bool,
 };
 
 List.defaultProps = defaultProps;


### PR DESCRIPTION
## Overview

Added an optional prop to `List` that allows the whole row to be clickable, instead of just on the checkbox/radio button.

Edit: simplified code so explanation below is outdated
<strike>
## Some explanation to why I implemented it like this:

- As defined by bootstrap, there must be a `Label` component wrapping everywhere that is clickable. This is why I have `Label` wrapping the entire main `div`, instead of having `Label` and `Input` as siblings (how it used to be)
  - When `Label` is wrapping an `Input`, we must explicitly change the pointer behavior
- `ListGroupItem` must still be the outermost component in order to be the child of `ListGroup`, otherwise the item borders aren't correct
  - Then, we remove the padding from `ListGroupItem` and instead put it on `Label`, so that this padding is also clickable
</strike>