### PR TITLE
feat: Add Optional RightChevron to ExpandableSection

### DIFF
--- a/src/components/ExpandableSection/ExpandableSection.spec.js
+++ b/src/components/ExpandableSection/ExpandableSection.spec.js
@@ -61,6 +61,14 @@ describe('<ExpandableSection />', () => {
     assert.equal(component.find(Collapse).prop('isOpen'), true, 'inner block should be visible');
   });
 
+  it('should render chevron on right side', () => {
+    const component = mount(
+      <ExpandableSection title="title" rightChevron>
+        <h1>Hello World!</h1>
+      </ExpandableSection>
+    );
+  });
+
   it('should call onToggle when state changed', () => {
     const onToggle = sinon.spy();
     const component = mount(

--- a/src/components/ExpandableSection/ExpandableSection.stories.js
+++ b/src/components/ExpandableSection/ExpandableSection.stories.js
@@ -29,6 +29,17 @@ export const Open = () => (
   </ExpandableSection>
 );
 
+export const RightChevron = () => (
+  <ExpandableSection
+    title={text('title', 'Click to expand me')}
+    open={boolean('open', ExpandableSection.defaultProps.open)}
+    onToggle={action('onToggle')}
+    rightChevron
+  >
+    <h2>BOO!</h2>
+  </ExpandableSection>
+);
+
 export const Header = () => (
   <ExpandableSection
     title={

--- a/src/components/ExpandableSection/ExpandableSection.tsx
+++ b/src/components/ExpandableSection/ExpandableSection.tsx
@@ -9,6 +9,7 @@ interface ExpandableSectionProps {
   onToggle?: (open: boolean) => void;
   open?: boolean;
   title: React.ReactNode;
+  rightChevron?: boolean;
 }
 
 const ExpandableSection: FC<ExpandableSectionProps> = ({
@@ -17,6 +18,7 @@ const ExpandableSection: FC<ExpandableSectionProps> = ({
   onToggle = () => {},
   open: defaultOpen,
   title,
+  rightChevron = false,
 }) => {
   const [open, setOpen] = useState(defaultOpen);
   useEffect(() => {
@@ -28,6 +30,12 @@ const ExpandableSection: FC<ExpandableSectionProps> = ({
     onToggle(!open);
   };
 
+  const iconProps = {
+    name: `chevron-${open ? 'up' : 'down'}`,
+    className: `text-muted ${rightChevron ? 'ms-1' : 'me-1'}`,
+    style: { transition: 'transform 200ms ease-in-out' },
+  };
+
   return (
     <section className={className}>
       <header>
@@ -36,13 +44,9 @@ const ExpandableSection: FC<ExpandableSectionProps> = ({
           className="d-flex align-items-center w-100"
           onClick={toggle}
         >
-          <Icon
-            name={`chevron-${open ? 'up' : 'down'}`}
-            className="text-muted me-1"
-            fixedWidth
-            style={{ transition: 'transform 200ms ease-in-out' }}
-          />
-          {title}
+          {rightChevron && title}
+          <Icon {...iconProps} fixedWidth />
+          {!rightChevron && title}
           <style jsx>
             {`
               b {


### PR DESCRIPTION
default:
<img width="208" alt="image" src="https://user-images.githubusercontent.com/12753924/204642205-909ccc74-47f8-4bf8-a8f7-5db4e2037cf1.png">

with `RightChevron` prop:
<img width="239" alt="image" src="https://user-images.githubusercontent.com/12753924/204642314-389e6ae7-83f4-46e5-a049-a3211cdbb32c.png">
