### PR TITLE
Enhancement: enable dynamic Combobox options (i.e. type-to-search)

### DIFF
--- a/src/components/Combobox/Combobox.spec.js
+++ b/src/components/Combobox/Combobox.spec.js
@@ -80,6 +80,18 @@ describe('<Combobox />', () => {
     sinon.assert.calledWith(mockOnChange, OPTIONS[2].value);
   });
 
+  it('should call onChangeText when user types', () => {
+    const mockOnChangeText = sinon.spy();
+    const combobox = render(<Combobox options={OPTIONS} onChangeText={mockOnChangeText} />);
+
+    const input = combobox.getByTestId('combobox-input');
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: 'R' } });
+
+    sinon.assert.called(mockOnChangeText);
+    sinon.assert.calledWith(mockOnChangeText, 'R');
+  });
+
   it('should close menu on blur', () => {
     const combobox = render(<Combobox options={OPTIONS} />);
 

--- a/src/components/Combobox/Combobox.tsx
+++ b/src/components/Combobox/Combobox.tsx
@@ -31,6 +31,7 @@ interface ComboboxProps<T> extends Omit<InputProps, 'onChange'> {
   dropdownProps?: DropdownProps;
   noResultsLabel?: string;
   onChange?: (value?: T | T[]) => void;
+  onChangeText?: (value: string) => void;
   onCreate?: (str: string) => T;
   isValidNewOption?: (label: string) => boolean;
   filterOptions?: (options: Option<T>[], value: string) => Option<T>[];
@@ -42,6 +43,7 @@ interface ComboboxProps<T> extends Omit<InputProps, 'onChange'> {
 const defaultProps = {
   noResultsLabel: 'No results found',
   onChange: () => {},
+  onChangeText: () => {},
   filterOptions: (o: Option<any>[], v: any) =>
     o.filter((option) => (v ? option.label.toLowerCase().indexOf(v.toLowerCase()) > -1 : true)),
   isValidNewOption: () => true,
@@ -61,6 +63,7 @@ function Combobox<T>({
   multi,
   noResultsLabel = defaultProps.noResultsLabel,
   onChange = defaultProps.onChange,
+  onChangeText = defaultProps.onChangeText,
   onCreate,
   isValidNewOption = defaultProps.isValidNewOption,
   filterOptions = defaultProps.filterOptions,
@@ -382,6 +385,7 @@ function Combobox<T>({
                 e.stopPropagation();
                 setInputValue(e.target.value);
 
+                onChangeText(e.target.value);
                 if (!multi && selected && cursorAtStart() && e.target.value === '') {
                   onChange(undefined);
                 }


### PR DESCRIPTION
My project is using `react-gears@5` which has an early iteration of `Combobox`. I want to enhance it, so I've already forked the component from `react-gears@7` into my project (hooray, modular libraries!) so I can benefit from the newer `Combobox` UX.

My goal with this PR is to illustrate my enhancements and maybe get them accepted upstream, so I can get rid of my fork when I upgrade to `react-gears@7`.

The enhancement proposal is tiny: I've added an `onChangeText` event that fires when the user is typing into the input, irrespective of which options exist or how the typing is refining the display of options. This gives parent components the chance to go find matching options, then update the `options` prop to display matching options.

In other words: this enhancement lets me use `Combobox` to build a search-select component that finds matching options on the server as the user types keystrokes.

The event name probably isn't quite right, since the user can pass any input `type` to `Combobox` (not just `text`). Naming choices aside, I think the idea is sound because it enables a powerful higher-level behavior without baking all of that complexity into the core component.

There are some usability issues with dynamic options (i.e. flicker) that I may need to address, but I'm happy to do that later if the team thinks this is the right direction.