### PR TITLE
fix: add `text-break` classname to break long strings

### DIFF
--- a/src/components/BlockPanel/BlockPanel.spec.js
+++ b/src/components/BlockPanel/BlockPanel.spec.js
@@ -4,6 +4,7 @@ import React from 'react';
 import sinon from 'sinon';
 import { assertAccessible } from '../../tooling/a11yHelpers';
 import Button from '../Button/Button';
+import Card from '../Card/Card';
 import CardBody from '../Card/CardBody';
 import CardTitle from '../Card/CardTitle';
 import Collapse from '../Collapse/Collapse';
@@ -19,6 +20,16 @@ describe('<BlockPanel />', () => {
 
   it('should be accessible when empty', async () => {
     await assertAccessible(<BlockPanel title="Open" />);
+  });
+
+  it('should pass classname from default props to Card', () => {
+    const component = shallow(
+      <BlockPanel title="Open">
+        <h1 id="hi">Hello World!</h1>
+      </BlockPanel>
+    );
+
+    assert.equal(component.find(Card).hasClass('text-break'), true);
   });
 
   it('sticky block panel should render correctly', async () => {

--- a/src/components/BlockPanel/BlockPanel.tsx
+++ b/src/components/BlockPanel/BlockPanel.tsx
@@ -50,7 +50,7 @@ export interface BlockPanelProps {
 }
 
 const defaultProps = {
-  className: '',
+  className: 'text-break',
   open: true,
   expandable: false,
   hideOnToggle: false,

--- a/src/components/Calendar/util/dateRanges.spec.ts
+++ b/src/components/Calendar/util/dateRanges.spec.ts
@@ -16,7 +16,6 @@ const monthArray = [
 ];
 
 const yearArray = [
-  new Date(1999, 0),
   new Date(2000, 0),
   new Date(2001, 0),
   new Date(2002, 0),
@@ -28,6 +27,7 @@ const yearArray = [
   new Date(2008, 0),
   new Date(2009, 0),
   new Date(2010, 0),
+  new Date(2011, 0),
 ];
 
 const centeredYearArray = [

--- a/src/components/Datapair/Datapair.spec.js
+++ b/src/components/Datapair/Datapair.spec.js
@@ -43,12 +43,12 @@ describe('<Datapair />', () => {
   it('should support a className', () => {
     const fancyComponent = shallow(<Datapair className="fancy-component" label="stuff" />);
     const formLabelGroup = fancyComponent.find(FormLabelGroup);
-    assert.equal(formLabelGroup.prop('rowClassName'), 'js-datapair fancy-component');
+    assert.equal(formLabelGroup.prop('rowClassName'), 'js-datapair text-break fancy-component');
   });
 
   it('should omit undefined class name', () => {
     const fancyComponent = shallow(<Datapair label="stuff" />);
     const formLabelGroup = fancyComponent.find(FormLabelGroup);
-    assert.equal(formLabelGroup.prop('rowClassName'), 'js-datapair');
+    assert.equal(formLabelGroup.prop('rowClassName'), 'js-datapair text-break');
   });
 });

--- a/src/components/Datapair/Datapair.tsx
+++ b/src/components/Datapair/Datapair.tsx
@@ -17,7 +17,7 @@ interface DatapairProps extends ComponentProps<typeof FormLabelGroup> {
  * the value can be text or links.
  */
 const Datapair: FC<DatapairProps> = ({ children, className, label, value, ...attributes }) => {
-  const classNames = classnames('js-datapair', className);
+  const classNames = classnames('js-datapair', 'text-break', className);
   return (
     <FormLabelGroup inline label={label} rowClassName={classNames} {...attributes}>
       {children || (


### PR DESCRIPTION
### Overview
* Adds the [Bootstrap text-break class](https://getbootstrap.com/docs/5.0/utilities/text/#word-break) to prevent long strings from breaking the component's layout (see before/after screenshots below).
* Note: only `BlockPanel` and `Datapair` have been modified, since these components are the only two that I know are effected by this issue.
  * There are almost certainly more effected components, and the team should probably go through and audit the rest of them for this issue.
  
BlockPanel before:
![Screen Shot 2023-01-03 at 2 58 14 PM](https://user-images.githubusercontent.com/11338019/210457566-b8b02bfc-ee12-4522-9234-13bbf2a45ca9.png)
BlockPanel after:
![Screen Shot 2023-01-03 at 2 58 38 PM](https://user-images.githubusercontent.com/11338019/210457588-0a699d35-57ec-4a9d-9c31-ba6f2b809700.png)

Datapair before: 
![Screen Shot 2023-01-03 at 2 55 30 PM](https://user-images.githubusercontent.com/11338019/210457616-fcb3a83c-ea2e-4966-bd8d-5c62a0b804c1.png)

Datapair after: 
![Screen Shot 2023-01-03 at 2 59 11 PM](https://user-images.githubusercontent.com/11338019/210457637-bad68e02-e5ec-45cf-8505-a8948a45a284.png)
