### PR TITLE
feat: Headerless blockpanel

### DIFF
--- a/src/components/BlockPanel/BlockPanel.spec.js
+++ b/src/components/BlockPanel/BlockPanel.spec.js
@@ -12,14 +12,80 @@ import Icon from '../Icon/Icon';
 import BlockPanel from './BlockPanel';
 
 describe('<BlockPanel />', () => {
-  it('should be empty with no children', () => {
-    const component = mount(<BlockPanel title="Open" />);
+  describe('when no title or children are provided', () => {
+    const example = () => <BlockPanel />;
 
-    assert.equal(component.find('CardBody').length, 0);
+    it('should be an empty card with no header', () => {
+      const component = mount(example());
+
+      assert.equal(component.find('Card').length, 1);
+      assert.equal(component.find('CardHeader').length, 0);
+      assert.equal(component.find('CardBody').length, 0);
+    });
+
+    it('should be accessible when empty with not header', async () => {
+      await assertAccessible(example());
+    });
   });
 
-  it('should be accessible when empty', async () => {
-    await assertAccessible(<BlockPanel title="Open" />);
+  describe('when a title is provided but no children', () => {
+    const example = () => <BlockPanel title="Open" />;
+
+    it('should be an empty card with a header ', () => {
+      const component = mount(example());
+
+      assert.equal(component.find('Card').length, 1);
+      assert.equal(component.find('CardHeader').length, 1);
+      assert.equal(component.find('CardTitle').text(), 'Open');
+      assert.equal(component.find('CardBody').length, 0);
+    });
+
+    it('should be accessible when empty', async () => {
+      await assertAccessible(example());
+    });
+  });
+
+  describe('when children are provided but no title', () => {
+    const example = () => (
+      <BlockPanel>
+        <h1 id="hi">Hello World</h1>
+      </BlockPanel>
+    );
+
+    it('should be empty with no children', () => {
+      const component = mount(example());
+
+      assert.equal(component.find('Card').length, 1);
+      assert.equal(component.find('CardHeader').length, 0);
+      assert.equal(component.find('CardBody').length, 1);
+      assert.equal(component.find('#hi').length, 1);
+    });
+
+    it('should be accessible when empty', async () => {
+      await assertAccessible(example());
+    });
+  });
+
+  describe('when title and children are provided', () => {
+    const example = () => (
+      <BlockPanel title="Open">
+        <h1 id="hi">Hello World!</h1>
+      </BlockPanel>
+    );
+
+    it('should have both header and body', () => {
+      const component = mount(example());
+
+      assert.equal(component.find('Card').length, 1);
+      assert.equal(component.find('CardHeader').length, 1);
+      assert.equal(component.find('CardTitle').text(), 'Open');
+      assert.equal(component.find('CardBody').length, 1);
+      assert.equal(component.find('#hi').length, 1);
+    });
+
+    it('should be accessible when empty', async () => {
+      await assertAccessible(example());
+    });
   });
 
   it('should pass classname from default props to Card', () => {

--- a/src/components/BlockPanel/BlockPanel.stories.js
+++ b/src/components/BlockPanel/BlockPanel.stories.js
@@ -38,7 +38,15 @@ export const LiveExample = () => (
     hideOnToggle={boolean('hideOnToggle', false)}
     open={boolean('open', true)}
   >
-    Now you see me.
+    {text('title') ? (
+      <div>
+        The header is shown when a <em>title</em> prop is provided
+      </div>
+    ) : (
+      <div>
+        The header is removed when the <em>title</em> prop is <em>undefined</em>
+      </div>
+    )}
   </BlockPanel>
 );
 

--- a/src/components/BlockPanel/BlockPanel.tsx
+++ b/src/components/BlockPanel/BlockPanel.tsx
@@ -54,7 +54,7 @@ const defaultProps = {
   open: true,
   expandable: false,
   hideOnToggle: false,
-  onToggle: () => { },
+  onToggle: () => {},
 };
 /**
  * BlockPanel is an extension to Bootstrap Card, which allows for expand/collapse and standardized header.
@@ -144,8 +144,9 @@ const BlockPanel: FC<BlockPanelProps> = ({
             {onEdit && (
               <Button
                 color="link"
-                className={`${color === 'primary' || color === 'dark' ? 'text-white' : ''
-                  } p-0 ms-2 me-1`}
+                className={`${
+                  color === 'primary' || color === 'dark' ? 'text-white' : ''
+                } p-0 ms-2 me-1`}
                 onClick={onEdit}
               >
                 Edit

--- a/src/components/BlockPanel/BlockPanel.tsx
+++ b/src/components/BlockPanel/BlockPanel.tsx
@@ -44,7 +44,7 @@ export interface BlockPanelProps {
   onEdit?: (event: React.MouseEvent<any, MouseEvent>) => void;
   onToggle?: (willOpen?: boolean) => void;
   open?: boolean;
-  title: ReactNode;
+  title?: ReactNode;
   stickyId?: string;
   bodyClassName?: string;
 }
@@ -54,7 +54,7 @@ const defaultProps = {
   open: true,
   expandable: false,
   hideOnToggle: false,
-  onToggle: () => {},
+  onToggle: () => { },
 };
 /**
  * BlockPanel is an extension to Bootstrap Card, which allows for expand/collapse and standardized header.
@@ -119,40 +119,41 @@ const BlockPanel: FC<BlockPanelProps> = ({
 
   return (
     <Card className={className} {...props}>
-      <CardHeader className={headerClassNames}>
-        <BlockPanelTitle
-          className="d-inline-flex align-items-center"
-          expandable={expandable}
-          onClick={toggle}
-        >
-          {expandable && (
-            <Icon
-              className={iconClassName}
-              name="chevron-up"
-              rotate={!isOpen ? 180 : undefined}
-              fixedWidth
-              style={{ transition: 'transform 200ms ease-in-out' }}
-            />
-          )}
-          <CardTitle tag="h2" className="m-0 my-1 me-auto">
-            {title}
-          </CardTitle>
-        </BlockPanelTitle>
-        <div className="d-inline-flex">
-          {controls && controls}
-          {onEdit && (
-            <Button
-              color="link"
-              className={`${
-                color === 'primary' || color === 'dark' ? 'text-white' : ''
-              } p-0 ms-2 me-1`}
-              onClick={onEdit}
-            >
-              Edit
-            </Button>
-          )}
-        </div>
-      </CardHeader>
+      {title && (
+        <CardHeader className={headerClassNames}>
+          <BlockPanelTitle
+            className="d-inline-flex align-items-center"
+            expandable={expandable}
+            onClick={toggle}
+          >
+            {expandable && (
+              <Icon
+                className={iconClassName}
+                name="chevron-up"
+                rotate={!isOpen ? 180 : undefined}
+                fixedWidth
+                style={{ transition: 'transform 200ms ease-in-out' }}
+              />
+            )}
+            <CardTitle tag="h2" className="m-0 my-1 me-auto">
+              {title}
+            </CardTitle>
+          </BlockPanelTitle>
+          <div className="d-inline-flex">
+            {controls && controls}
+            {onEdit && (
+              <Button
+                color="link"
+                className={`${color === 'primary' || color === 'dark' ? 'text-white' : ''
+                  } p-0 ms-2 me-1`}
+                onClick={onEdit}
+              >
+                Edit
+              </Button>
+            )}
+          </div>
+        </CardHeader>
+      )}
       {children && (
         <Collapse isOpen={children ? !expandable || isOpen : false} onExited={() => onClosed()}>
           {(!expandable || hideOnToggle || !collapsed) && (


### PR DESCRIPTION
We have 2 components for rendering a Bootstrap Card: BlockPanel and Card. Since BlockPanel has more functionality, the general advice is to use BlockPanel unless you don't need a header, then use Card.

This PR allows BlockPanel to render without a header by not providing a `title` prop.

**Ultimately** We should rename BlockPanel to Card and only have this one component.

[Example Usage](https://github.com/appfolio/apm_bundle/pull/64411/commits/997af31a9de008baa3f4f7bd2ae716be19f312bd)

<img width="1143" alt="image" src="https://user-images.githubusercontent.com/24777/211075197-6fd1c279-7b3c-402d-a111-b8f81b82ad5d.png">
