### PR TITLE
Allow other properties in FilterType

### DIFF
--- a/src/components/FilterList/FilterList.d.ts
+++ b/src/components/FilterList/FilterList.d.ts
@@ -4,6 +4,7 @@ interface FilterType {
   label: string;
   value: string;
   removable?: boolean;
+  [index: string]: any;
 }
 
 interface FilterListProps {

--- a/src/components/FilterList/FilterList.spec.js
+++ b/src/components/FilterList/FilterList.spec.js
@@ -43,10 +43,10 @@ describe('<FilterList />', () => {
   it('passes onRemove callback to LabelBadge', () => {
     const onRemove = sinon.stub();
     const wrapper = mount(
-      <FilterList filters={[{ label: 'hello', value: 'world' }]} onRemove={onRemove} />
+      <FilterList filters={[{ label: 'hello', value: 'world', myVal: 'value' }]} onRemove={onRemove} />
     );
     wrapper.find('.btn-close').simulate('click');
-    sinon.assert.calledWith(onRemove);
+    sinon.assert.calledWith(onRemove, { label: "hello", myVal: "value", value: "world" });
   });
 
   it('passes removable to LabelBadge', () => {


### PR DESCRIPTION
I have a use case for passing some other properties that `onRemove` need in order. the `label` and `value` are not enough to know what to do in my `onRemove`