### PR TITLE
fix: onSelect should not be called when the List selected property is updated

### DIFF
--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -94,10 +94,6 @@ function List<T extends Item>({
   const [selectAllId] = useState(() => uniqueId('selectall-'));
   const selectAllRef = useRef<HTMLInputElement>(null);
 
-  useDeepCompareEffect(
-    () => onSelect(Array.from(selection.values())),
-    [Array.from(selection.values()), onSelect]
-  );
   useDeepCompareEffect(() => replaceSelection(selected), [selected, replaceSelection]);
 
   useDeepCompareEffect(() => {
@@ -117,16 +113,19 @@ function List<T extends Item>({
   }, [items, Array.from(selection.values())]);
 
   const handleSelection = (item: T, checked?: boolean) => {
+    let newSelection = selection;
+
     if (select === 'checkbox' || select === 'switch') {
       if (hasItem(item) && !checked) {
-        removeItem(item);
+        newSelection = removeItem(item);
       } else if (checked) {
-        addItem(item);
+        newSelection = addItem(item);
       }
     } else if (!hasItem(item)) {
       clearSelection();
-      addItem(item);
+      newSelection = addItem(item);
     }
+    onSelect(Array.from(newSelection.values()));
   };
 
   const handleSelectAll = () => {
@@ -134,14 +133,17 @@ function List<T extends Item>({
     const unselectableItems = items.filter((item) => !selectable(item));
     const unselectableSelectedItems = unselectableItems.filter((item) => selected.includes(item));
     const allSelectableSelected = selectableItems.every((item) => hasItem(item));
+    let newSelection;
 
     if (allSelectableSelected) {
       // deselecting all items except those are selected and unselectable
-      replaceSelection(unselectableSelectedItems);
+      newSelection = unselectableSelectedItems;
     } else {
       // selecting all selectable items
-      replaceSelection(unselectableSelectedItems.concat(selectableItems));
+      newSelection = unselectableSelectedItems.concat(selectableItems);
     }
+    replaceSelection(newSelection);
+    onSelect(Array.from(newSelection));
   };
 
   const [sortProperty, setSortProperty] = useState(sort.property);

--- a/src/hooks/useMap.spec.ts
+++ b/src/hooks/useMap.spec.ts
@@ -28,10 +28,11 @@ describe('useMap', () => {
 
   describe('add', () => {
     it('should add an item', () => {
+      let ret;
       const { result } = renderHook(() => useMap(initial));
 
       act(() => {
-        result.current.add('Charlie');
+        ret = result.current.add('Charlie');
       });
 
       assert.deepStrictEqual(
@@ -42,6 +43,8 @@ describe('useMap', () => {
           ['Charlie', 'Charlie'],
         ])
       );
+
+      assert.strictEqual(ret, result.current.map);
     });
   });
 
@@ -61,13 +64,16 @@ describe('useMap', () => {
 
   describe('remove', () => {
     it('should remove an item', () => {
+      let ret;
       const { result } = renderHook(() => useMap(initial));
 
       act(() => {
-        result.current.remove('Alpha');
+        ret = result.current.remove('Alpha');
       });
 
       assert.deepStrictEqual(result.current.map, new Map([['Bravo', 'Bravo']]));
+
+      assert.strictEqual(ret, result.current.map);
     });
 
     it('should remove an object using keyMapper', () => {
@@ -84,11 +90,12 @@ describe('useMap', () => {
 
   describe('toggle', () => {
     it('should toggle existence of an item', () => {
+      let ret;
       const { result } = renderHook(() => useMap(initial));
 
       act(() => {
         result.current.toggle('Alpha');
-        result.current.toggle('Charlie');
+        ret = result.current.toggle('Charlie');
       });
 
       assert.deepStrictEqual(
@@ -98,6 +105,8 @@ describe('useMap', () => {
           ['Charlie', 'Charlie'],
         ])
       );
+
+      assert.strictEqual(ret, result.current.map);
     });
   });
 

--- a/src/hooks/useMap.ts
+++ b/src/hooks/useMap.ts
@@ -5,18 +5,25 @@ export default function useMap<T>(defaultValue: T[], keyMapper: (value: T) => an
   const has = (value: T) => map.has(keyMapper(value));
   const add = (value: T) => {
     map.set(keyMapper(value), value);
-    setMap(new Map(map));
+
+    const newMap = new Map(map);
+    setMap(newMap);
+
+    return newMap;
   };
   const remove = (value: T) => {
     map.delete(keyMapper(value));
-    setMap(new Map(map));
+
+    const newMap = new Map(map);
+    setMap(newMap);
+
+    return newMap;
   };
   const toggle = (value: T) => {
     if (has(value)) {
-      remove(value);
-    } else {
-      add(value);
+      return remove(value);
     }
+    return add(value);
   };
   const clear = () => map.clear();
   const replace = useCallback(


### PR DESCRIPTION
**Overview**
Fixed a bug where the `onSelect` property for the `List` component (and components that inherit from `List` such as `SortableList`) is called when the `selected` attribute changes.

The parent component of `List` triggers the change of the `selected` property so it does not need to be aware of the selection change.

Only when a checkbox, switch or radio button in the `List` is selected / unselected should the `onSelect` callback be triggered.