### PR TITLE
CollapsableText: Allow for any children, move show more button to bottom

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,6 +27,21 @@
     "no-confusing-arrow": "off",
     "no-only-tests/no-only-tests": "error",
     "no-nested-ternary": "off",
+    "no-restricted-syntax": [
+      "error",
+      {
+        "selector": "ForInStatement",
+        "message": "for..in loops iterate over the entire prototype chain, which is virtually never what you want. Use Object.{keys,values,entries}, and iterate over the resulting array."
+      },
+      {
+        "selector": "LabeledStatement",
+        "message": "Labels are a form of GOTO; using them makes code confusing and hard to maintain and understand."
+      },
+      {
+        "selector": "WithStatement",
+        "message": "`with` is disallowed in strict mode because it makes code impossible to predict and optimize."
+      }
+    ],
     "react/default-props-match-prop-types": ["error", { "allowRequiredDefaults": true }],
     "react/no-array-index-key": "error",
     "react/no-find-dom-node": "error",

--- a/src/components/CollapsableText/CollapsableText.stories.js
+++ b/src/components/CollapsableText/CollapsableText.stories.js
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
 import { boolean, number, text } from '@storybook/addon-knobs';
 import React from 'react';
 import Icon from '../Icon/Icon';
@@ -18,17 +19,19 @@ export default {
 export const LiveExample = () => (
   <CollapsableText
     collapsed={boolean('collapsed', CollapsableText.defaultProps.collapsed)}
-    maxLength={number('maxLength', CollapsableText.defaultProps.maxLength)}
+    maxLines={number('maxLines', CollapsableText.defaultProps.maxLines)}
     moreLabel={text('showMore', CollapsableText.defaultProps.moreLabel)}
     lessLabel={text('lessLabel', CollapsableText.defaultProps.lessLabel)}
   >
+    Some text <strong>with bold</strong> and <a href="#">links and other things</a>
+    <br />
     {loremIpsum}
   </CollapsableText>
 );
 
-export const ShorterThanMaxLength = () => (
+export const ShorterThanMaxLines = () => (
   <div>
-    <CollapsableText maxLength={number('maxLength', 2048)}>{loremIpsum}</CollapsableText>
+    <CollapsableText maxLines={number('maxLines', 2)}>Short text</CollapsableText>
   </div>
 );
 

--- a/src/components/CollapsableText/CollapsableText.tsx
+++ b/src/components/CollapsableText/CollapsableText.tsx
@@ -1,59 +1,75 @@
-import React, { useEffect, useState } from 'react';
-import Button, { ButtonProps } from '../Button/Button';
+/* eslint-disable react/no-unused-prop-types */
+import React, { useState, useRef } from 'react';
+import { useIntervalRef } from '../../hooks/useIntervalRef';
+import Button from '../Button/Button';
 
-const Toggle = ({ children, ...props }: ButtonProps) => (
-  <Button color="link" size="sm" className="p-0 m-0 ms-2" {...props}>
-    {children}
-  </Button>
-);
-
-export interface CollapsableTextProps {
-  children?: string;
-  collapsed?: boolean;
-  lessLabel?: React.ReactNode;
-  maxLength?: number;
-  moreLabel?: React.ReactNode;
+function getEllipsisStyle(maxLines: number) {
+  maxLines = Math.max(maxLines, 1);
+  return {
+    display: '-webkit-box',
+    // max-height for browsers that don't support -webkit-line-clamp.
+    maxHeight: `calc(1.5em * ${maxLines})`,
+    overflow: 'hidden',
+    WebkitLineClamp: maxLines,
+    WebkitBoxOrient: 'vertical',
+  } as const;
 }
 
-const CollapsableText = ({
-  children = '',
-  collapsed: defaultCollapsed = true,
-  lessLabel = 'Show Less',
-  maxLength = 256,
-  moreLabel = 'Show More',
-}: CollapsableTextProps) => {
-  const [collapsed, setCollapsed] = useState(defaultCollapsed);
-  const toggle = () => setCollapsed(!collapsed);
+export interface CollapsableTextProps {
+  children?: React.ReactNode;
+  collapsed?: boolean;
+  lessLabel?: React.ReactNode;
+  moreLabel?: React.ReactNode;
+  /**  @deprecated maxLength has no effect. Use maxLines instead */
+  maxLength?: number;
+  maxLines?: number;
+}
 
-  useEffect(() => setCollapsed(defaultCollapsed), [defaultCollapsed]);
+export default function CollapsableText({
+  children,
+  collapsed = CollapsableText.defaultProps.collapsed,
+  lessLabel = CollapsableText.defaultProps.lessLabel,
+  moreLabel = CollapsableText.defaultProps.moreLabel,
+  maxLines = CollapsableText.defaultProps.maxLines,
+}: CollapsableTextProps) {
+  const [isCollapsed, setIsCollapsed] = useState(collapsed);
+  const [hideToggle, setHideToggle] = useState(collapsed);
 
-  if (children.length < maxLength) {
-    return children;
+  // Can't easily use a resize utility here because nothing can detect when only scrollHeight changes.
+  // Using an interval is not ideal, but it works.
+  const checkSizeRef = useIntervalRef((el) => {
+    setHideToggle(isCollapsed && el.clientHeight >= el.scrollHeight);
+  }, 200);
+
+  // If the collapsed prop changes, update the state.
+  // This is bad practice, we should instead have a defaultCollapsed prop and the collapsed prop
+  // should fully control the state if provided.
+  // TODO: Add defaultCollapsed and onToggle props. Always respect collapsed prop unless undefined.
+  const lastCollapsedProp = useRef(collapsed);
+  if (lastCollapsedProp.current !== collapsed) {
+    lastCollapsedProp.current = collapsed;
+    setIsCollapsed(collapsed);
   }
-  if (collapsed) {
-    return (
-      <span>
-        {children.substring(0, maxLength).trim()}&hellip;{' '}
-        <Toggle onClick={() => toggle()}>{moreLabel}</Toggle>
-      </span>
-    );
-  }
+
+  const textContainerStyle = isCollapsed ? getEllipsisStyle(maxLines) : undefined;
 
   return (
-    <span>
-      {children} <Toggle onClick={() => toggle()}>{lessLabel}</Toggle>
-    </span>
+    <div className="d-inline-flex flex-column align-items-start mw-100">
+      <div ref={checkSizeRef} style={textContainerStyle}>
+        {children}
+      </div>
+      {!hideToggle && (
+        <Button color="link" onClick={() => setIsCollapsed((c) => !c)}>
+          {isCollapsed ? moreLabel : lessLabel}
+        </Button>
+      )}
+    </div>
   );
-};
+}
 
 CollapsableText.defaultProps = {
-  children: '',
   collapsed: true,
   lessLabel: 'Show Less',
-  maxLength: 256,
+  maxLines: 2,
   moreLabel: 'Show More',
 };
-
-CollapsableText.displayName = 'CollapsableText';
-
-export default CollapsableText;

--- a/src/hooks/useIntervalRef.ts
+++ b/src/hooks/useIntervalRef.ts
@@ -1,0 +1,27 @@
+import { useEffect, useRef } from 'react';
+import { useLatestFn, useLatestRef } from './useLatest';
+
+// Returns a callback ref to be used on an element.
+// The callback will be called every `intervalMs` milliseconds with the element as an argument.
+export function useIntervalRef<T extends Element>(callback: (el: T) => any, intervalMs = 200) {
+  const elRef = useRef<T>();
+  const timeoutRef = useRef<number>();
+  const intervalMsRef = useLatestRef(intervalMs);
+  const cb = useLatestFn(callback);
+
+  const cleanup = () => clearTimeout(timeoutRef.current);
+  const runInterval = () => {
+    cb(elRef.current!);
+    timeoutRef.current = window.setTimeout(runInterval, intervalMsRef.current);
+  };
+
+  useEffect(() => cleanup, []);
+
+  return (el: T | null) => {
+    if (el && elRef.current !== el) {
+      elRef.current = el;
+      cleanup();
+      runInterval();
+    }
+  };
+}

--- a/src/hooks/useLatest.ts
+++ b/src/hooks/useLatest.ts
@@ -1,0 +1,19 @@
+import { useRef } from 'react';
+
+// Returns a ref that always has the last provided value.
+// This is useful for cases where you need to access the
+// latest value of a prop inside a callback, e.g. a useEffect callback.
+export function useLatestRef<T>(value: T) {
+  const ref = useRef(value);
+  ref.current = value;
+  return ref;
+}
+
+// Creates a stable function that always calls the last version of the provided function.
+// It's mainly used for when useEffect subscribes to something and passes a callback.
+// The changing of that callback would normally cause the effect to re-run, unsubscribing and resubscribing.
+// This hook prevents that from happening while keeping the callback up to date.
+export function useLatestFn<T extends (...args: any[]) => any>(fn: T) {
+  const ref = useLatestRef(fn);
+  return useRef((...args: any[]) => ref.current(...args)).current as T;
+}


### PR DESCRIPTION
Before:
![Screenshot 2023-05-04 at 5 55 22 PM](https://user-images.githubusercontent.com/12418905/236358754-c5205736-80e7-45f4-a5e8-76d08cffbec7.png)

After:
<img width="486" alt="Screenshot 2023-05-06 at 7 42 05 PM" src="https://user-images.githubusercontent.com/12418905/236657661-97a35c61-6edb-4d32-8b79-3de6931a4234.png">

This is a soft-breaking change. `maxLength` prop is not respected. It's now `maxLines`.