### PR TITLE
fix(SortableTable): Fix alignment TS type

### DIFF
--- a/src/components/Table/SortableTable.d.ts
+++ b/src/components/Table/SortableTable.d.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { TableProps } from '../Table/Table';
 import { HeaderProps } from './components/Header';
 
-type HorizontalAlignment = 'left' | 'center' | 'right';
+type HorizontalAlignment = 'left' | 'center' | 'right' | 'start' | 'end';
 
 export interface SortableColumn<T> extends Omit<HeaderProps, 'children' | 'onSort'> {
   align?: HorizontalAlignment;


### PR DESCRIPTION
We [deprecated](https://github.com/appfolio/react-gears/blame/399ce0ae354a90f4a4a3fe48f56cfcd0a0875df7/src/components/Table/SortableTable.js#L14-L19) `left` and `right` as alignment options but didn't update the corresponding TS type. This PR addresses this issue.