### PR TITLE
Makes passed style props additive rather than replacing in tooltipbutton

### DIFF
--- a/src/components/Tooltip/TooltipButton.tsx
+++ b/src/components/Tooltip/TooltipButton.tsx
@@ -39,7 +39,7 @@ const TooltipButton: FC<TooltipButtonProps> = ({
         <Button
           aria-describedby={tooltipId}
           disabled={disabled}
-          style={{ pointerEvents: disabled ? 'none' : 'auto' }}
+          style={{ pointerEvents: disabled ? 'none' : 'auto', ...props.style }}
           {...props}
         >
           {children}


### PR DESCRIPTION
Working on components for snoop-doc revealed that style props passed in would overwrite an existing style prop necessary for properly handling disabled state. 

This change makes the passed in style props complement, rather than overwrite the existing behavior