### PR TITLE
Align Modal Text Color with Design System

### DIFF
--- a/src/components/FeedbackButton/FeedbackButton.spec.tsx
+++ b/src/components/FeedbackButton/FeedbackButton.spec.tsx
@@ -34,7 +34,6 @@ describe('<FeedbackButton />', () => {
     const ratingSubtitle = within(feedbackModal).getByText(
       'So far, how satisfied are you with this feature?'
     );
-    expect(ratingSubtitle).toHaveClass('text-danger');
     const ratingAsterisk = within(ratingSubtitle).getByText('*');
     expect(ratingAsterisk).toHaveClass('text-danger');
     const feedbackModalRating = within(feedbackModal).getByTestId('feedback-modal-rating');
@@ -65,7 +64,6 @@ describe('<FeedbackButton />', () => {
     const commentSubtitle = within(feedbackModal).getByText(
       'How could we improve the way this works for you?'
     );
-    expect(commentSubtitle).toHaveClass('text-danger');
     const commentAsterisk = within(commentSubtitle).getByText('*');
     expect(commentAsterisk).toHaveClass('text-danger');
     const commentInput = within(feedbackModal).getByPlaceholderText(

--- a/src/components/FeedbackButton/components/FeedbackModalBody.tsx
+++ b/src/components/FeedbackButton/components/FeedbackModalBody.tsx
@@ -40,7 +40,7 @@ const FeedbackModalBody: FC<FeedbackModalBodyProps> = ({
       visible={ratingIncluded}
       required={ratingRequired}
       text={ratingSubtitle}
-      labelClassNames={classnames({ 'js-rating-subtitle': true, 'text-danger': ratingRequired })}
+      labelClassNames={classnames({ 'js-rating-subtitle': true })}
     />
     {ratingIncluded && (
       <FeedbackModalRating
@@ -54,10 +54,7 @@ const FeedbackModalBody: FC<FeedbackModalBodyProps> = ({
       visible={commentIncluded}
       required={commentRequired}
       text={commentSubtitle}
-      labelClassNames={classnames({
-        'js-rating-subtitle': true,
-        'text-danger': commentRequired,
-      })}
+      labelClassNames={classnames({ 'js-rating-subtitle': true })}
     />
     {commentIncluded && (
       <Input


### PR DESCRIPTION
Removes logic to turn field text to red color when the field is required in order to align with design system. The text will now be rendered in black while the red asterisk is kept as the required indicator.