### PR TITLE
feat: allow labelClassName to be overridden

### DIFF
--- a/src/components/Form/FormLabelGroup.spec.js
+++ b/src/components/Form/FormLabelGroup.spec.js
@@ -62,6 +62,15 @@ describe('<FormLabelGroup />', () => {
       assert.equal(label.children().text(), 'First Name');
     });
 
+    it('should allow label classname to be overridden', () => {
+      props.labelClassName = 'text-lg-start';
+      const component = shallow(<FormLabelGroup {...props}>Hello World</FormLabelGroup>);
+
+      const label = component.find(Label);
+      assert.equal(label.length, 1);
+      assert.equal(label.prop('className'), 'text-lg-start');
+    });
+
     it('should include an asterisk after the label text when required', () => {
       const component = shallow(
         <FormLabelGroup {...props} required>

--- a/src/components/Form/FormLabelGroup.tsx
+++ b/src/components/Form/FormLabelGroup.tsx
@@ -27,6 +27,7 @@ type FormLabelGroupProps = React.PropsWithChildren<{
   inputId?: string;
   label?: React.ReactNode;
   labelSize?: keyof typeof labelSizeTranslations;
+  labelClassName?: string;
   required?: boolean;
   rowClassName?: string;
   size?: string;
@@ -50,6 +51,7 @@ function FormLabelGroup({
   inputId,
   label,
   labelSize = defaultProps.labelSize,
+  labelClassName,
   required,
   rowClassName,
   size,
@@ -65,12 +67,14 @@ function FormLabelGroup({
     },
     rowClassName
   );
-  const labelClassNames = classnames({
-    'text-sm-end pe-0': !stacked,
-    'text-danger': feedback,
-    'text-success': validFeedback,
-    'visually-hidden visually-hidden-focusable': srLabel,
-  });
+  const labelClassNames =
+    labelClassName ??
+    classnames({
+      'text-sm-end pe-0': !stacked,
+      'text-danger': feedback,
+      'text-success': validFeedback,
+      'visually-hidden visually-hidden-focusable': srLabel,
+    });
   const hiddenClassNames = classnames(
     {
       'is-invalid': feedback,


### PR DESCRIPTION
Sometimes users want to be able to use custom spacing for their labels. This gives them that flexibility