### PR TITLE
 DEBT-320 react-gears correct placeholder color

### DIFF
--- a/src/components/Select/SelectArrow.js
+++ b/src/components/Select/SelectArrow.js
@@ -159,7 +159,7 @@ const SelectArrow = ({ isOpen, render }) => (
           white-space: nowrap;
         }
         .Select-placeholder {
-          color: #517b98;
+          color: #637989;
           font-style: italic;
         }
         .Select-input {


### PR DESCRIPTION
### Replace the new default placeholder color

The new placeholder text replacement color is too blue, too attention grabbing in layout: replace new color with a more muted color that passes AA.

* Replace `.Select-placeholder` color `#517b98` with `#637989`

