### PR TITLE
Export combobox props

### DIFF
--- a/src/components/Combobox/Combobox.tsx
+++ b/src/components/Combobox/Combobox.tsx
@@ -25,7 +25,7 @@ type OptionGroup<T> = {
   options: Option<T>[];
 };
 
-interface ComboboxProps<T> extends Omit<InputProps, 'onChange'> {
+export interface ComboboxProps<T> extends Omit<InputProps, 'onChange'> {
   options: Option<T>[] | OptionGroup<T>[];
   direction?: Direction;
   dropdownProps?: DropdownProps;


### PR DESCRIPTION
This commit exports ComboboxProps so that it can be used outside of react-gears. This allows clients of react-gears to interface with the prop types for this component.