### PR TITLE
Add resetPageOnRowChange prop to UncontrolledTable

### DIFF
--- a/src/components/Table/UncontrolledTable.js
+++ b/src/components/Table/UncontrolledTable.js
@@ -14,6 +14,7 @@ export default class UncontrolledTable extends React.Component {
     onPageChange: PropTypes.func,
     page: PropTypes.number,
     pageSize: PropTypes.number,
+    resetPageOnRowChange: PropTypes.bool,
     selected: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
     sort: PropTypes.shape({
       column: PropTypes.string,
@@ -31,6 +32,7 @@ export default class UncontrolledTable extends React.Component {
     onPageChange: () => {},
     page: 0,
     pageSize: 10,
+    resetPageOnRowChange: true,
     selected: [],
     sort: {
       ascending: true,
@@ -175,7 +177,7 @@ export default class UncontrolledTable extends React.Component {
       this.setState({ expanded: [] });
     }
 
-    if (rowsChanged) {
+    if (nextProps.resetPageOnRowChange && rowsChanged) {
       this.setState({ page: 0 });
     }
 

--- a/src/components/Table/UncontrolledTable.spec.js
+++ b/src/components/Table/UncontrolledTable.spec.js
@@ -618,14 +618,19 @@ describe('<UncontrolledTable />', () => {
 
   describe('UNSAFE_componentWillReceiveProps()', () => {
     let wrapper;
+    let columns;
+    let rows;
+    let expanded;
+    let selected;
+
     beforeEach(() => {
-      const columns = [{ header: 'Name', cell: (row) => row.name }];
-      const rows = [
+      columns = [{ header: 'Name', cell: (row) => row.name }];
+      rows = [
         { name: 'Alpha', key: '1' },
         { name: 'Bravo', key: '2' },
       ];
-      const expanded = [{ name: 'Alpha', key: '1' }];
-      const selected = [{ name: 'Bravo', key: '2' }];
+      expanded = [{ name: 'Alpha', key: '1' }];
+      selected = [{ name: 'Bravo', key: '2' }];
 
       wrapper = mount(
         <UncontrolledTable
@@ -689,6 +694,39 @@ describe('<UncontrolledTable />', () => {
         'the selected state should not change'
       );
       assert.strictEqual(wrapper.state().page, 0, 'the page state should have been set to 0');
+    });
+
+    it('should reset state for expanded, but not page if a rows key attributes have changed and resetPageOnRowChange is false', () => {
+      wrapper = mount(
+        <UncontrolledTable
+          columns={columns}
+          rows={rows}
+          expanded={expanded}
+          page={1}
+          selected={selected}
+          resetPageOnRowChange={false}
+        />
+      );
+      assert(wrapper.props().expanded.length > 0, 'the expanded props should be non empty');
+      assert(wrapper.props().selected.length > 0, 'the selected props should be non empty');
+      assert.strictEqual(wrapper.props().page, 1, 'the page prop should be 1');
+
+      const prevSelectedLength = wrapper.props().selected.length;
+      const newProps = JSON.parse(JSON.stringify(wrapper.props()));
+      newProps.rows[0].key = '3';
+      wrapper.instance().UNSAFE_componentWillReceiveProps(newProps);
+
+      assert.strictEqual(
+        wrapper.state().expanded.length,
+        0,
+        'the expanded state should be reset to empty'
+      );
+      assert.strictEqual(
+        wrapper.state().selected.length,
+        prevSelectedLength,
+        'the selected state should not change'
+      );
+      assert.strictEqual(wrapper.state().page, 1, 'the page state should still be 1');
     });
 
     it('should reset state for selected if a change is detected in the selected key attributes have changed', () => {


### PR DESCRIPTION
- This prop allows the client to specify whether the page should be reset when the rows change