### PR TITLE
Update default behavior of uncontrolled table to only update page on rows change if the user is outside of the page bounds

### DIFF
--- a/src/components/Table/UncontrolledTable.js
+++ b/src/components/Table/UncontrolledTable.js
@@ -14,7 +14,6 @@ export default class UncontrolledTable extends React.Component {
     onPageChange: PropTypes.func,
     page: PropTypes.number,
     pageSize: PropTypes.number,
-    resetPageOnRowChange: PropTypes.bool,
     selected: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
     sort: PropTypes.shape({
       column: PropTypes.string,
@@ -32,7 +31,6 @@ export default class UncontrolledTable extends React.Component {
     onPageChange: () => {},
     page: 0,
     pageSize: 10,
-    resetPageOnRowChange: true,
     selected: [],
     sort: {
       ascending: true,
@@ -177,8 +175,13 @@ export default class UncontrolledTable extends React.Component {
       this.setState({ expanded: [] });
     }
 
-    if (nextProps.resetPageOnRowChange && rowsChanged) {
-      this.setState({ page: 0 });
+    if (rowsChanged) {
+      const numPages = Math.ceil(nextProps.rows.length / nextProps.pageSize);
+      if (!numPages) {
+        this.setState({ page: 0 });
+      } else if (this.state.page + 1 > numPages) {
+        this.setState({ page: numPages - 1 });
+      }
     }
 
     if (selectedChanged) {


### PR DESCRIPTION
* Rather than having a prop for if the page should be reset when the rows change, the default behavior will be to only update the page if the user is out of bounds when the rows change
* This also fixes a bug with the resetPageOnRowChange prop where, if this was false and the user was on the last page, then it would be possible for the user. to be outside of the page bounds if rows were removed