### PR TITLE
Don't capture non-left mouse clicks on combobox

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "react-text-mask": "~5.0.2",
     "react-transition-group": "^2.9.0",
     "react-use": "^17.3.2",
-    "reactstrap": "^9.2.0",
+    "reactstrap": "^9.2.2",
     "storybook-source-link": "^2.0.8",
     "styled-jsx": "^5.1.1",
     "text-mask-addons": "^3.8.0",

--- a/src/components/Combobox/Combobox.spec.js
+++ b/src/components/Combobox/Combobox.spec.js
@@ -214,6 +214,31 @@ describe('<Combobox />', () => {
     sinon.assert.calledWith(mockOnChange, OPTIONS[1].value);
   });
 
+  it('should select an option with left-click only', () => {
+    const mockOnChange = sinon.spy();
+    const combobox = render(<Combobox options={OPTIONS} onChange={mockOnChange} />);
+    const input = combobox.getByTestId('react-gears-combobox-input');
+
+    fireEvent.focus(input);
+    assert.strictEqual(
+      combobox.getByTestId('react-gears-combobox-dropdownmenu').getAttribute('aria-hidden'),
+      'false'
+    );
+
+    const option = combobox.getByText('D-O');
+    fireEvent.mouseDown(option, { button: 2 });
+    assert.strictEqual(
+      combobox.getByTestId('react-gears-combobox-dropdownmenu').getAttribute('aria-hidden'),
+      'false'
+    );
+
+    fireEvent.mouseDown(option);
+    assert.strictEqual(
+      combobox.getByTestId('react-gears-combobox-dropdownmenu').getAttribute('aria-hidden'),
+      'true'
+    );
+  });
+
   it('should deselect option on backspace', () => {
     let value;
     const mockOnChange = (v) => {
@@ -265,7 +290,7 @@ describe('<Combobox />', () => {
     );
   });
 
-  it('should open options if input is clicked', async () => {
+  it('should open options if input is left-clicked', async () => {
     const combobox = render(<Combobox options={OPTIONS} value={3} />);
 
     assert.equal(
@@ -274,8 +299,14 @@ describe('<Combobox />', () => {
     );
 
     const input = combobox.getByTestId('react-gears-combobox-input');
-    fireEvent.mouseDown(input);
 
+    fireEvent.mouseDown(input, { button: 2 });
+    assert.equal(
+      combobox.getByTestId('react-gears-combobox-dropdownmenu').getAttribute('aria-hidden'),
+      'true'
+    );
+
+    fireEvent.mouseDown(input);
     assert.equal(
       combobox.getByTestId('react-gears-combobox-dropdownmenu').getAttribute('aria-hidden'),
       'false'
@@ -303,6 +334,27 @@ describe('<Combobox />', () => {
 
     fireEvent.mouseDown(caret);
 
+    assert.equal(
+      combobox.getByTestId('react-gears-combobox-dropdownmenu').getAttribute('aria-hidden'),
+      'false'
+    );
+  });
+
+  it('should open options with dropdown toggle left-click only', () => {
+    const combobox = render(<Combobox options={OPTIONS} />);
+    const caret = combobox.getByTestId('react-gears-combobox-button');
+    assert.equal(
+      combobox.getByTestId('react-gears-combobox-dropdownmenu').getAttribute('aria-hidden'),
+      'true'
+    );
+
+    fireEvent.mouseDown(caret, { button: 2 });
+    assert.equal(
+      combobox.getByTestId('react-gears-combobox-dropdownmenu').getAttribute('aria-hidden'),
+      'true'
+    );
+
+    fireEvent.mouseDown(caret);
     assert.equal(
       combobox.getByTestId('react-gears-combobox-dropdownmenu').getAttribute('aria-hidden'),
       'false'

--- a/src/components/Combobox/Combobox.tsx
+++ b/src/components/Combobox/Combobox.tsx
@@ -279,6 +279,10 @@ function Combobox<T>({
             setFocusedOptionIndex(visibleIndex);
           }}
           onMouseDown={(ev) => {
+            if (ev.button !== 0) {
+              return;
+            }
+
             ev.preventDefault();
             ev.stopPropagation();
             selectOption(option.value);
@@ -311,6 +315,10 @@ function Combobox<T>({
           data-testid="react-gears-combobox-dropdownitem-create-new-option"
           disabled={!isValidNewOption(inputValue)}
           onMouseDown={(ev) => {
+            if (ev.button !== 0) {
+              return;
+            }
+
             ev.preventDefault();
             ev.stopPropagation();
             createOption();
@@ -389,17 +397,22 @@ function Combobox<T>({
                   onChange(undefined);
                 }
               }}
-              onMouseDown={(e) => {
+              onMouseDown={(ev) => {
+                if (ev.button !== 0) {
+                  ev.preventDefault();
+                  return;
+                }
+
                 if (!multi && selected) {
                   inputElement!.current!.setSelectionRange(0, 0);
 
                   if ((selected as Option<T>).label === inputValue) {
-                    e.preventDefault();
+                    ev.preventDefault();
                   }
                 }
 
                 // @ts-ignore
-                e.target.focus();
+                ev.target.focus();
               }}
               onKeyDown={handleOptionsKeyboardNav}
               onKeyPress={clearSelectedPreview}
@@ -415,6 +428,10 @@ function Combobox<T>({
               disabled={disabled}
               active={open}
               onMouseDown={(ev: React.MouseEvent<HTMLButtonElement>) => {
+                if (ev.button !== 0) {
+                  return;
+                }
+
                 ev.stopPropagation();
                 setOpen(!open);
               }}

--- a/yarn.lock
+++ b/yarn.lock
@@ -148,7 +148,7 @@ __metadata:
     react-text-mask: ~5.0.2
     react-transition-group: ^2.9.0
     react-use: ^17.3.2
-    reactstrap: ^9.2.0
+    reactstrap: ^9.2.2
     regenerator-runtime: ^0.13.7
     sinon: ^9.2.1
     storybook-source-link: ^2.0.8
@@ -14977,9 +14977,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"reactstrap@npm:^9.2.0":
-  version: 9.2.0
-  resolution: "reactstrap@npm:9.2.0"
+"reactstrap@npm:^9.2.2":
+  version: 9.2.2
+  resolution: "reactstrap@npm:9.2.2"
   dependencies:
     "@babel/runtime": ^7.12.5
     "@popperjs/core": ^2.6.0
@@ -14990,7 +14990,7 @@ __metadata:
   peerDependencies:
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
-  checksum: e6b056a3f8e82ef7dec681e87949be01ee66e3700c2c4a1136bdf2aa08366e16301358f3a4438bfa5da9f73ede2c3e758c6d4e90a9cebd2720bdb63ddd715725
+  checksum: 1d859f562e24f65720813dfbc0198e6921ce55344106e6f5b7518efe2b31cd7ad4fdaf29820b1ff0fd9dd70ecfa98bb5911b81770ba0e192d0e1deb9fdeb92d2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
[APT-1372](https://appfolio.atlassian.net/browse/APT-1372)

Right-clicking on a combobox input or menu option should not behave like a left click. this commit skips the custom mouse down handling if not left-click. Impetus for this change is the use of combobox within our bulk-uploader component. The cells of the table each have a custom right-click menu, but when a user right clicks on a cell that contains a combobox, both the right-click menu and the combobox dropdown appear, which is not desired (see video below)

Before:

https://github.com/appfolio/react-gears/assets/75824353/e6e0e796-f2cd-4e4e-8ada-3eca1e281733

After:

https://github.com/appfolio/react-gears/assets/75824353/af8da752-8483-4ef4-8071-060f8c7ea6db

Reason for change:

https://github.com/appfolio/react-gears/assets/75824353/f8f9e767-8428-4ff0-a9a3-8c1cd94b4c90

[APT-1372]: https://appfolio.atlassian.net/browse/APT-1372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ