### PR TITLE
DEBT-346  react-gears - Correct date test and add data-testId

### DIFF
--- a/src/components/Calendar/MonthCalendar.tsx
+++ b/src/components/Calendar/MonthCalendar.tsx
@@ -5,7 +5,7 @@ import Col from '../Layout/Col';
 import Row from '../Layout/Row';
 import Nav from '../Nav/Nav';
 import NavLabel from './components/NavLabel';
-import { getMonths, getYears } from './util/dateRanges';
+import { getMonths, getPreviousYears } from './util/dateRanges';
 
 export interface MonthCalendarProps {
   date?: Date;
@@ -54,7 +54,7 @@ const MonthCalendar: FC<MonthCalendarProps> = ({
 
         <Col className="border-start">
           <Nav pills className="d-block p-1 m-0" style={{ columnCount: 2, columnGap: 0 }}>
-            {getYears(date, centerYearSelection).map((monthYear) => (
+            {getPreviousYears(date, centerYearSelection).map((monthYear) => (
               <NavLabel
                 selected={date.getFullYear() === monthYear.getFullYear()}
                 label={format(monthYear, yearFormat)}

--- a/src/components/Calendar/util/dateRanges.spec.ts
+++ b/src/components/Calendar/util/dateRanges.spec.ts
@@ -1,4 +1,4 @@
-import { getMonths, getYears } from './dateRanges';
+import { getMonths, getPreviousYears } from './dateRanges';
 
 const monthArray = [
   new Date(2000, 0),
@@ -52,13 +52,13 @@ describe('Calendar - dateRanges', () => {
     });
   });
 
-  describe('getYears', () => {
+  describe('getPreviousYears', () => {
     it('can get a range of years', () => {
-      expect(getYears(new Date(2000, 0, 1))).toEqual(yearArray);
+      expect(getPreviousYears(new Date(2011, 0, 1))).toEqual(yearArray);
     });
 
     it('can get a centered range of years', () => {
-      expect(getYears(new Date(2000, 0, 1), true)).toEqual(centeredYearArray);
+      expect(getPreviousYears(new Date(2000, 0, 1), true)).toEqual(centeredYearArray);
     });
   });
 });

--- a/src/components/Calendar/util/dateRanges.ts
+++ b/src/components/Calendar/util/dateRanges.ts
@@ -1,19 +1,17 @@
-import mod from '../../../util/mod';
 import range from '../../../util/range';
 
 export const getMonths = (date: Date) =>
   range(0, 12).map((month) => new Date(date.getFullYear(), month, 1));
 
-export const getYears = (date: Date, centerYears: boolean = false) => {
-  const now = new Date();
-  const currentYear = date.getFullYear();
+export const getPreviousYears = (date: Date, centerYears: boolean = false) => {
+  const inputYear = date.getFullYear();
   const month = date.getMonth();
-  let end = currentYear + 1;
+  let end = inputYear + 1;
+
   if (centerYears) {
     end += 6;
-  } else {
-    end += mod(now.getFullYear() - currentYear, 12);
   }
+
   const start = end - 12;
   return range(start, end).map((year) => new Date(year, month, 1));
 };


### PR DESCRIPTION
### Correct date test and add data-testId

The previous PR with branch `debt-346-rg-add-data-testid-to-components` bumped into a test failure due to incorrect setup.

* Add data-testId as previously done
* correct date test, refactor date utility