### PR TITLE
FEE-462: re-write Badge to use badge-{color} classes

### DIFF
--- a/src/components/Badge/Badge.stories.tsx
+++ b/src/components/Badge/Badge.stories.tsx
@@ -21,13 +21,11 @@ export const Default = () => (
 );
 
 export const Pills = () => (
-  <div>
+  <div className="d-flex gap-3">
     {colors.map((color) => (
-      <div>
-        <Badge pill color={color}>
-          {color}
-        </Badge>
-      </div>
+      <Badge pill color={color}>
+        {color}
+      </Badge>
     ))}
   </div>
 );

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -1,3 +1,30 @@
-import { Badge } from 'reactstrap';
+import classNames from 'classnames';
+import React, { type PropsWithChildren } from 'react';
+
+export interface BadgeProps {
+  className?: string;
+  color?: string;
+  href?: string;
+  pill?: boolean;
+  tag?: keyof JSX.IntrinsicElements;
+  [key: string]: any;
+}
+
+function Badge({
+  className,
+  color = 'secondary',
+  href,
+  pill = false,
+  tag: Tag = 'span',
+  ...props
+}: PropsWithChildren<BadgeProps>) {
+  const classes = classNames(className, 'badge', `badge-${color}`, pill ? 'rounded-pill' : false);
+
+  if (href) {
+    Tag = 'a';
+  }
+
+  return <Tag {...props} className={classes} />;
+}
 
 export default Badge;

--- a/src/tooling/colors.js
+++ b/src/tooling/colors.js
@@ -5,6 +5,7 @@ export const colors = [
   'danger',
   'warning',
   'info',
+  'ai',
   'light',
   'dark',
 ];


### PR DESCRIPTION
- Re-writes the Badge component without using the `reactstrap` implementation
- Uses `badge-{color}` for the color classes (`reactstrap` uses `bg-{color}`)

This re-write attempts to maintain backward compatibility with the `reactstrap` implementation. If `Badge` is ever re-written in a non-backward compatible way, it will be added to `react-libs` so there is a migration path.
