### PR TITLE
Table Align: Convert left/right to start/end

### DIFF
--- a/src/components/Table/SortableTable.d.ts
+++ b/src/components/Table/SortableTable.d.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { TableProps } from '../Table/Table';
 import { HeaderProps } from './components/Header';
 
-type HorizontalAlignment = 'left' | 'center' | 'right';
+type HorizontalAlignment = 'start' | 'center' | 'end';
 
 export interface SortableColumn<T> extends Omit<HeaderProps, 'children' | 'onSort'> {
   align?: HorizontalAlignment;

--- a/src/components/Table/SortableTable.js
+++ b/src/components/Table/SortableTable.js
@@ -110,7 +110,7 @@ class SortableTable extends React.Component {
     ...Table.propTypes,
     columns: PropTypes.arrayOf(
       PropTypes.shape({
-        align: PropTypes.oneOf(['left', 'center', 'right']),
+        align: PropTypes.oneOf(['start', 'center', 'end']),
         active: PropTypes.bool,
         ascending: PropTypes.bool,
         cell: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),

--- a/src/components/Table/SortableTable.spec.js
+++ b/src/components/Table/SortableTable.spec.js
@@ -296,9 +296,9 @@ describe('<SortableTable />', () => {
   it('should render correct align when present', () => {
     const columns = [
       { header: 'Default', cell: () => '-', footer: '-' },
-      { header: 'Left', cell: () => '-', footer: '-', align: 'left' },
+      { header: 'Start', cell: () => '-', footer: '-', align: 'start' },
       { header: 'Center', cell: () => '-', footer: '-', align: 'center' },
-      { header: 'Right', cell: () => '-', footer: '-', align: 'right' },
+      { header: 'End', cell: () => '-', footer: '-', align: 'end' },
     ];
     const wrapper = mount(<SortableTable columns={columns} rows={[1, 2, 3]} />);
 
@@ -318,7 +318,7 @@ describe('<SortableTable />', () => {
   it('should render correct column classnames when present', () => {
     const columns = [
       { header: 'Default', cell: () => '-', footer: '-' },
-      { header: 'Left', cell: () => '-', footer: '-', className: 'whatever' },
+      { header: 'Start', cell: () => '-', footer: '-', className: 'whatever' },
     ];
     const wrapper = mount(<SortableTable columns={columns} rows={[1, 2, 3]} />);
 
@@ -332,7 +332,7 @@ describe('<SortableTable />', () => {
   describe('Expandable column', () => {
     const columns = [
       { header: 'Default', cell: () => '-', footer: '-' },
-      { header: 'Left', cell: () => '-', footer: '-', className: 'whatever' },
+      { header: 'Start', cell: () => '-', footer: '-', className: 'whatever' },
     ];
 
     it('should not render expandable column helper when onExpand not present', () => {
@@ -362,7 +362,7 @@ describe('<SortableTable />', () => {
   describe('Selectable column', () => {
     const columns = [
       { header: 'Default', cell: () => '-', footer: '-' },
-      { header: 'Left', cell: () => '-', footer: '-', className: 'whatever' },
+      { header: 'Start', cell: () => '-', footer: '-', className: 'whatever' },
     ];
 
     it('should not render selectable column helper when rowSelected not present', () => {

--- a/src/components/Table/SortableTable.stories.js
+++ b/src/components/Table/SortableTable.stories.js
@@ -175,7 +175,7 @@ export const AlignColumn = () => (
           cell: (row) => row.first,
         },
         {
-          align: 'left',
+          align: 'start',
           header: 'Left Align',
           key: 'last',
           cell: (row) => row.last,
@@ -187,7 +187,7 @@ export const AlignColumn = () => (
           cell: (row) => fecha.format(row.dob, 'MM/DD/YYYY'),
         },
         {
-          align: 'right',
+          align: 'end',
           header: 'Right Align',
           key: 'email',
           cell: EmailCell,

--- a/src/components/Table/UncontrolledTable.spec.js
+++ b/src/components/Table/UncontrolledTable.spec.js
@@ -260,9 +260,9 @@ describe('<UncontrolledTable />', () => {
   it('should render correct align when present', () => {
     const columns = [
       { header: 'Default', cell: () => '-', footer: '-' },
-      { header: 'Left', cell: () => '-', footer: '-', align: 'left' },
+      { header: 'Start', cell: () => '-', footer: '-', align: 'start' },
       { header: 'Center', cell: () => '-', footer: '-', align: 'center' },
-      { header: 'Right', cell: () => '-', footer: '-', align: 'right' },
+      { header: 'End', cell: () => '-', footer: '-', align: 'end' },
     ];
     const wrapper = mount(<UncontrolledTable columns={columns} rows={[1, 2, 3]} />);
 
@@ -282,7 +282,7 @@ describe('<UncontrolledTable />', () => {
   it('should render correct column classnames when present', () => {
     const columns = [
       { header: 'Default', cell: () => '-', footer: '-' },
-      { header: 'Left', cell: () => '-', footer: '-', className: 'whatever' },
+      { header: 'Start', cell: () => '-', footer: '-', className: 'whatever' },
     ];
     const wrapper = mount(<UncontrolledTable columns={columns} rows={[1, 2, 3]} />);
 

--- a/src/components/Table/UncontrolledTable.stories.js
+++ b/src/components/Table/UncontrolledTable.stories.js
@@ -212,7 +212,7 @@ export const CustomFooter = () => (
           key: 'cost',
           cell: (row) => row.cost,
           width: '25%',
-          align: 'right',
+          align: 'end',
         },
       ]}
       rows={[
@@ -297,7 +297,7 @@ export const CustomExpandColumn = () => (
       sort={{ column: 'last', ascending: true }}
       expandable
       expandableColumn={{
-        align: 'right',
+        align: 'end',
         header: 'Actions',
         cell: EditButton,
       }}


### PR DESCRIPTION
part of bootstrap 5 migration
https://getbootstrap.com/docs/5.0/migration/

this is causing a tremendous amount of lint errors in property app, which after this PR is merged we can address:

<img width="871" alt="image" src="https://github.com/appfolio/react-gears/assets/9400356/7e55756d-e4e5-4e20-a916-1b2ce9cf609b">
