### PR TITLE
Make the Modal cancel buttons `btn-link` in Storybook

### DIFF
--- a/src/components/Modal/Modal.stories.js
+++ b/src/components/Modal/Modal.stories.js
@@ -35,7 +35,7 @@ export const LiveExample = () => (
     <ModalFooter>
       <ButtonToolbar>
         <Button color="primary">Do Something</Button>
-        <Button>Cancel</Button>
+        <Button color="link">Cancel</Button>
       </ButtonToolbar>
     </ModalFooter>
   </Modal>
@@ -55,7 +55,7 @@ export const Autofocus = () => (
     <ModalFooter>
       <ButtonToolbar>
         <Button color="primary">Do Something</Button>
-        <Button>Cancel</Button>
+        <Button color="link">Cancel</Button>
       </ButtonToolbar>
     </ModalFooter>
   </Modal>


### PR DESCRIPTION
The [Coastline documentation](https://www.figma.com/file/JMNsXbjX8G17A7oKgrQUZs/Coastline-Components?type=design&node-id=4978-45704&mode=design&t=vbQRmpEYxStdJWQ5-0) specifically states to always use a link button to represent the “cancel” action within a button grouping.
