### PR TITLE
feat(APT-1610): add portalEl prop to Combobox

### DIFF
--- a/src/components/Combobox/Combobox.spec.js
+++ b/src/components/Combobox/Combobox.spec.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import { render, fireEvent, cleanup } from '@testing-library/react';
+import { render, fireEvent, cleanup, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import sinon from 'sinon';
@@ -359,6 +359,21 @@ describe('<Combobox />', () => {
       combobox.getByTestId('react-gears-combobox-dropdownmenu').getAttribute('aria-hidden'),
       'false'
     );
+  });
+
+  it('can render the dropdown menu inside a portal', async () => {
+    render(<Combobox options={OPTIONS} portalEl={document.body} />);
+    const toggle = await screen.findByTestId('react-gears-combobox-button');
+    await userEvent.click(toggle);
+    const dropdown = await screen.findByTestId('react-gears-combobox-dropdownmenu');
+
+    expect(dropdown.parentElement).toEqual(document.body);
+
+    expect(
+      within(await screen.findByTestId('react-gears-combobox-dropdown')).queryByTestId(
+        'react-gears-combobox-dropdownmenu'
+      )
+    ).toBeNull();
   });
 
   describe('default filterOptions ', () => {

--- a/src/components/Combobox/Combobox.stories.js
+++ b/src/components/Combobox/Combobox.stories.js
@@ -203,3 +203,23 @@ export const CustomOptions = () => {
     />
   );
 };
+
+export const PortalElement = () => {
+  const [value, setValue] = useState();
+  return (
+    <>
+      <div>value: {value}</div>
+      <Combobox
+        direction={select('direction', ['', 'down', 'up'], '')}
+        onChange={setValue}
+        options={options}
+        value={value}
+        disabled={boolean('disabled', Combobox.defaultProps.disabled)}
+        noResultsLabel={text('noResultsLabel', Combobox.defaultProps.noResultsLabel)}
+        placeholder={text('placeholder', Combobox.defaultProps.placeholder)}
+        inputClassName={text('inputClassName', '')}
+        portalEl={document.body}
+      />
+    </>
+  );
+};


### PR DESCRIPTION
This utilizes [createPortal](https://react.dev/reference/react-dom/createPortal) to allow space/position constrained implementations of `Combobox` to render the dropdown menu in another component so the positioning of the menu is not dependent on the parent element.

In BulkUploader we need this functionality to prevent menus from being hidden behind table headers:

before: (because the dropdown menu could not be displayed outside the bounds of the table, popperjs positioned the menu on top, but it was hidden under the sticky header and couldn't be positioned above it because of the positioning of virtualized rows)
![image](https://github.com/appfolio/react-gears/assets/3128659/9d680054-5613-43d2-99e7-c0d68b86628e)


after: (using the `portalEl` prop we can render the dropdown menu as a child of `document.body` which allows popper to position it below and allow it to extend outside the boundary of the table regardless of the positioning of its parent row)
![image](https://github.com/appfolio/react-gears/assets/3128659/647f4312-3b50-4884-8d5b-3d667e8167ce)
