### PR TITLE
Update .tool-versions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,1 @@
-nodejs lts-gallium
-yarn 1.22.19
+nodejs 20.14.0


### PR DESCRIPTION
bump node to 20.14.0 (latest LTS)
  - latest asdf (0.14.0) no longer accepts node version aliases and gallium (16...) is old

remove yarn version because it is already define in .yarnrc.yml