### PR TITLE
fix: adjust blackpanel header color to use subtle variation

### DIFF
--- a/src/components/BlockPanel/BlockPanel.tsx
+++ b/src/components/BlockPanel/BlockPanel.tsx
@@ -107,7 +107,7 @@ const BlockPanel: FC<BlockPanelProps> = ({
     'align-items-center',
     'justify-content-between',
     {
-      [`bg-${color}`]: color,
+      [`bg-${color}-subtle`]: color,
       'text-white': color === 'primary' || color === 'dark',
     },
     headerClassName


### PR DESCRIPTION
Adjusting the BlockPanel component to use our `-subtle` variation when setting the color or the header.

Before:
<img width="828" alt="Screenshot 2024-07-18 at 10 28 12 AM" src="https://github.com/user-attachments/assets/d529761b-1f5f-4563-a5ee-70e467674a83">

After:
<img width="779" alt="Screenshot 2024-07-18 at 10 29 40 AM" src="https://github.com/user-attachments/assets/f394e585-1115-44fc-9a1f-fb7a5a888bca">

