### PR TITLE
ScrollContainer: Replace broken sample image in docs

### DIFF
--- a/src/components/ScrollContainer/ScrollContainer.stories.js
+++ b/src/components/ScrollContainer/ScrollContainer.stories.js
@@ -21,7 +21,7 @@ export const Default = (args) => (
   <div>
     <ScrollContainer {...args}>
       <img
-        src="https://upload.wikimedia.org/wikipedia/commons/thumb/8/87/Flag-map_of_the_world.svg/1000px-Flag-map_of_the_world.svg.png"
+        src="https://upload.wikimedia.org/wikipedia/commons/f/f7/World_map_2011_CIA_World_Factbook.svg"
         alt="Map"
       />
     </ScrollContainer>
@@ -35,7 +35,7 @@ export const MaxHeight = (args) => (
   <div>
     <ScrollContainer {...args}>
       <img
-        src="https://upload.wikimedia.org/wikipedia/commons/thumb/8/87/Flag-map_of_the_world.svg/1000px-Flag-map_of_the_world.svg.png"
+        src="https://upload.wikimedia.org/wikipedia/commons/f/f7/World_map_2011_CIA_World_Factbook.svg"
         alt="Map"
       />
     </ScrollContainer>
@@ -71,7 +71,7 @@ export const CustomTheme = (args) => (
     {...args}
   >
     <img
-      src="https://upload.wikimedia.org/wikipedia/commons/thumb/8/87/Flag-map_of_the_world.svg/1000px-Flag-map_of_the_world.svg.png"
+      src="https://upload.wikimedia.org/wikipedia/commons/f/f7/World_map_2011_CIA_World_Factbook.svg"
       alt="Map"
     />
   </ScrollContainer>


### PR DESCRIPTION
Replaces the previous broken image in the ScrollContainer docs. Uses the same image that's used in the Save Scroll Position example so user can see the difference between the setups.

Before:
![image](https://github.com/user-attachments/assets/5c1757cd-2012-4f18-bdcf-e94aa14cd2dc)

After:
![image](https://github.com/user-attachments/assets/52f2d6f1-a7b7-413c-8134-9f6dcaddd8c1)
