### PR TITLE
[FEE-596] Fix overflow layout bug

### DIFF
--- a/src/components/HasManyFields/HasManyFieldsRow.tsx
+++ b/src/components/HasManyFields/HasManyFieldsRow.tsx
@@ -75,7 +75,7 @@ const HasManyFieldsRow = ({
 
   return (
     <Row className={classNames} {...props}>
-      <Col>{children}</Col>
+      <Col style={{ minWidth: 0 }}>{children}</Col>
       {deletable && (
         <Col xs="auto" className="js-delete-col ps-3 d-flex">
           {button}


### PR DESCRIPTION
fix(HasManyFieldsRow): adds minWidth: 0 to HasManyFieldsRow to allow it to be smaller then it's content



BEFORE
<img width="844" alt="Screenshot 2024-08-13 at 4 10 26 PM" src="https://github.com/user-attachments/assets/1f3d8e7b-ec71-45ad-8190-a945e647a5f4">


AFTER
<img width="835" alt="Screenshot 2024-08-13 at 4 11 15 PM" src="https://github.com/user-attachments/assets/495f5121-e7cc-447d-ab65-fd71c3f25c69">
