### PR TITLE
APT-1938: Export HorizontalAlignment type

### DIFF
--- a/src/components/Table/SortableTable.d.ts
+++ b/src/components/Table/SortableTable.d.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { TableProps } from '../Table/Table';
 import { HeaderProps } from './components/Header';
 
-type HorizontalAlignment = 'start' | 'center' | 'end';
+export type HorizontalAlignment = 'start' | 'center' | 'end';
 
 export interface SortableColumn<T> extends Omit<HeaderProps, 'children' | 'onSort'> {
   align?: HorizontalAlignment;


### PR DESCRIPTION
Exporting the `HorizontalAlignment` type will allow it to be reused in apps using gears. 