### PR TITLE
[FEE-927] add offset on Tooltip popover content

### DIFF
--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -9,6 +9,7 @@ const Tooltip: FC<TooltipProps> = ({
   isOpen = defaultProps.isOpen,
   fade = defaultProps.fade,
   target,
+  placement = 'top',
   ...props
 }) => {
   const [open, setOpen] = useState(isOpen);
@@ -17,8 +18,26 @@ const Tooltip: FC<TooltipProps> = ({
     setOpen(!open);
   }, [open]);
 
+  //adds offset for the popper placement base on placement prop
+  const offsets: Record<string, [number, number]> = {
+    top: [0, 5],
+    bottom: [0, 5],
+    left: [0, 8],
+    right: [0, 8],
+  };
+
+  const offset = offsets[placement];
+
   return (
-    <InnerTooltip isOpen={open} toggle={handleToggle} fade={fade} target={target} {...props} />
+    <InnerTooltip
+      isOpen={open}
+      toggle={handleToggle}
+      fade={fade}
+      target={target}
+      placement={placement}
+      offset={offset}
+      {...props}
+    />
   );
 };
 


### PR DESCRIPTION
Our current Tooltip implementation does not have much, if any, space between the tooltip arrow and the content it's pointing to. This fix adds an offset based on the placement direction.

Before:
<img width="146" alt="Screenshot 2025-02-03 at 5 13 33 PM" src="https://github.com/user-attachments/assets/2a225a65-049a-4d98-9b63-0c29865945d4" />
<img width="131" alt="Screenshot 2025-02-03 at 5 09 46 PM" src="https://github.com/user-attachments/assets/44f141a4-b4f6-4da4-9852-8076f35151bf" />
<img width="167" alt="Screenshot 2025-02-03 at 5 13 44 PM" src="https://github.com/user-attachments/assets/645e7686-527e-4952-99bd-a11ad2f265a0" />
<img width="160" alt="Screenshot 2025-02-03 at 5 13 51 PM" src="https://github.com/user-attachments/assets/3cb8c32c-da1b-4965-8757-9f33af797689" />


After:
<img width="148" alt="Screenshot 2025-02-03 at 5 12 37 PM" src="https://github.com/user-attachments/assets/c56b6f5d-f874-43bf-9a8f-70a9d95c3356" />
<img width="147" alt="Screenshot 2025-02-03 at 5 14 45 PM" src="https://github.com/user-attachments/assets/a8152d88-30b9-4e2d-89af-28a77478060f" />
<img width="178" alt="Screenshot 2025-02-03 at 5 12 45 PM" src="https://github.com/user-attachments/assets/64706d39-ca2e-4572-8185-7c15c01cb420" />
<img width="209" alt="Screenshot 2025-02-03 at 5 14 56 PM" src="https://github.com/user-attachments/assets/5d85a9df-9ddf-42d5-af39-bfbeea39b76e" />

