### PR TITLE
[KNOW-154]: Use CODEOWNERS to determine Developer Portal catalog ownership

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -18,4 +18,4 @@ metadata:
 spec:
   type: library
   lifecycle: maintenance
-  owner: boyz2dev
+  owner: engineering


### PR DESCRIPTION
This change is part of a trial run to update a team's name throughout the places it appears
in code ownership-related files.

[_Created by Sourcegraph batch change `modethirteen/team-name-change-trial-platform-front-end`._](https://sourcegraph.appf.io/users/modethirteen/batch-changes/team-name-change-trial-platform-front-end)