### PR TITLE
[KNOW-154]: Use CODEOWNERS to determine Developer Portal catalog ownership

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -18,4 +18,4 @@ metadata:
 spec:
   type: library
   lifecycle: maintenance
-  owner: engineering
+  owner: appfolio-developers


### PR DESCRIPTION
This updates CODEOWNERS to use new team names and sets it up to be the source-of-truth for both code and Developer Portal catalog entity ownership.

[_Created by Sourcegraph batch change `modethirteen/20250608-team-name-change`._](https://sourcegraph.appf.io/users/modethirteen/batch-changes/20250608-team-name-change)