### PR TITLE
OWNER-221: fix DateInput not clearing when controlled value becomes undefined

### DIFF
--- a/src/components/Input/DateInput.js
+++ b/src/components/Input/DateInput.js
@@ -248,6 +248,13 @@ export default class DateInput extends React.Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
+    if (prevProps.value && !this.props.value) {
+      this.setState({ value: '' });
+      if (this.inputEl) {
+        this.inputEl.value = '';
+        this.inputEl.setAttribute('value', '');
+      }
+    }
     this.setInputValue();
     if (this.props.onClose && this.state.open !== prevState.open && !this.state.open) {
       const value = this.props.value !== undefined ? this.props.value : this.state.value;

--- a/src/components/Input/DateInput.spec.js
+++ b/src/components/Input/DateInput.spec.js
@@ -560,6 +560,34 @@ describe('<DateInput />', () => {
     });
   });
 
+  describe('controlled value', () => {
+    it('should clear displayed value when value prop changes to undefined after user interaction', () => {
+      const component = mount(<DateInput value="1/1/2025" />);
+      const input = component.find('input');
+      assert.equal(input.getDOMNode().value, '1/1/2025');
+
+      // Simulate user typing which sets internal state.value
+      input.simulate('change', { target: { value: '2/2/2025' } });
+      component.setProps({ value: '2/2/2025' });
+      component.update();
+      assert.equal(input.getDOMNode().value, '2/2/2025');
+
+      component.setProps({ value: undefined });
+      component.update();
+      assert.equal(input.getDOMNode().value, '');
+    });
+
+    it('should clear displayed value when value prop changes to empty string', () => {
+      const component = mount(<DateInput value="1/1/2025" />);
+      const input = component.find('input');
+      assert.equal(input.getDOMNode().value, '1/1/2025');
+
+      component.setProps({ value: '' });
+      component.update();
+      assert.equal(input.getDOMNode().value, '');
+    });
+  });
+
   describe('accessibility', () => {
     it('should contain screen reader only label for buttons', () => {
       const component = mount(<DateInput />);


### PR DESCRIPTION
## Summary
- Fixes a bug where `DateInput` did not clear its displayed value when the controlled `value` prop changed from a date string to `undefined` or `''`. This specifically happened when using `reset` on a form using `react-hook-forms` with a controlled `DateInput`.
- Adds reset logic in `componentDidUpdate` to clear both internal state and the DOM input element when `value` transitions from truthy to falsy
- Adds tests for both `undefined` and empty string reset scenarios


🤖 Generated with [Claude Code](https://claude.com/claude-code)