### PR TITLE
fix: use local action for JFrog OIDC instead of private public-packages action

### DIFF
--- a/.github/actions/prep-secure-registries/action.yml
+++ b/.github/actions/prep-secure-registries/action.yml
@@ -1,0 +1,25 @@
+name: Prepare Secure Registries
+description: 'Authenticate to the internal JFrog proxy via OIDC and export JFROG_ACCESS_TOKEN for subsequent steps.'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Exchange OIDC token with JFrog
+      uses: jfrog/setup-jfrog-cli@v5
+      id: exchange
+      env:
+        JF_URL: https://appfolio.jfrog.io
+      with:
+        oidc-provider-name: appfolio-github-oidc
+        oidc-audience: jfrog-appfolio
+
+    - name: Export JFROG_ACCESS_TOKEN
+      shell: bash
+      run: |
+        TOKEN="${{ steps.exchange.outputs.oidc-token }}"
+        if [ -z "$TOKEN" ]; then
+          echo "::error::JFrog OIDC token exchange failed — no token returned"
+          exit 1
+        fi
+        echo "::add-mask::${TOKEN}"
+        echo "JFROG_ACCESS_TOKEN=${TOKEN}" >> $GITHUB_ENV

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version-file: '.tool-versions'
-      - uses: appfolio/public-packages/setup@v1
+      - uses: ./.github/actions/prep-secure-registries
       - run: yarn install --immutable
       - run: yarn dist
       - run: npm version prerelease --preid=$GITHUB_HEAD_REF-`git rev-parse --short HEAD` --git-tag-version=false --commit-hooks=false

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -38,7 +38,7 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
         with:
           node-version-file: '.tool-versions'
-      - uses: appfolio/public-packages/setup@v1
+      - uses: ./.github/actions/prep-secure-registries
         if: ${{ steps.release.outputs.release_created }}
       - run: yarn install --immutable
         if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
## Summary

PR #1317 replaced the local `.github/actions/prep-secure-registries` action with `appfolio/public-packages/setup@v1`. Since `react-gears` is a **public** repo and `appfolio/public-packages` is **private**, GitHub blocks the cross-repo action reference — this broke prereleases.

## Changes

- **Recreate** `.github/actions/prep-secure-registries/action.yml` as a local composite action that does only the JFrog OIDC token exchange and exports `JFROG_ACCESS_TOKEN` (lifted from the public-packages `setup` action).
- **Repoint** `prerelease.yml` and `release-please.yml` from `appfolio/public-packages/setup@v1` to `./.github/actions/prep-secure-registries`.

## Why the trimmed-down action is sufficient

The public action also overrides registries, blocks external registries, and configures RubyGems. None of that is needed here:

- **Registry override** — `.yarnrc.yml` already hardcodes the JFrog registry server and reads `${JFROG_ACCESS_TOKEN}` from env, which this action sets.
- **Blocklist / RubyGems** — not relevant to a JS-only library publish flow.

`jfrog/setup-jfrog-cli@v5` is a public marketplace action (same category as the `actions/*` and `aws-actions/*` actions already in use), so it's fine — the restriction was specifically the private `appfolio/*` action repo.

## Testing

The prerelease workflow runs on this PR, so a green prerelease check validates the fix end-to-end.