### PR TITLE
fix: upgrade release-please-action v3 → v4 (Node 24 compatibility)

### DIFF
--- a/.github/workflows/release-please-pr.yml
+++ b/.github/workflows/release-please-pr.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: '24.11.0'
-      - uses: google-github-actions/release-please-action@v3
+      - uses: google-github-actions/release-please-action@v4
         id: release-please
         with:
           release-type: node

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -26,7 +26,7 @@ jobs:
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
     steps:
-      - uses: google-github-actions/release-please-action@v3
+      - uses: google-github-actions/release-please-action@v4
         id: release
         with:
           release-type: node


### PR DESCRIPTION
## Summary

Upgrades `release-please-action` from `@v3` to `@v4` in both release workflows to fix the failing `release-please` job on master.

## Root cause

The `release-please` job has been failing at release creation with:

```
✔ Creating 1 releases for pull #1318
##[error]release-please failed: Resource not accessible by integration
```

This is **not** a token-permissions issue — the runtime log confirms the `GITHUB_TOKEN` is granted `Contents: write` (and write on issues/pull-requests/etc.). The actual cause is the **Node runtime**:

| | Apr 24 (8.19.3) ✅ | Jun 17 (8.19.4) ❌ |
|---|---|---|
| Action | `release-please-action@v3` (SHA `db8f2c60`) | same SHA |
| Token | `Contents: write` | `Contents: write` |
| Node | ran on **Node 20** | **forced to Node 24** |

GitHub's Node 20 EOL took effect **2026-06-02**, force-running the deprecated v3 action on Node 24. v3's bundled octokit/fetch stack breaks on Node 24 and surfaces as a misleading `Resource not accessible by integration`. The last good release ran the *same action SHA* on Node 20.

## Fix

Bump to `@v4` (Node 24-compatible) in both `release-please.yml` and `release-please-pr.yml`. v4 keeps the same simple inputs (`release-type`/`package-name`/`command`), matching the working `appfolio/browser-reporter` setup — so this is a one-line-per-file change with no config migration.

## Impact

Once merged, the `release-please` job should successfully tag **v8.19.4** off the already-merged release PR #1318, flip its `autorelease: pending` label to `tagged`, and unblock the release cycle (which is currently wedged — no new release PRs open while #1318 is untagged).

## Notes

- Separate from #1321 (the prerelease JFrog local-action fix); different failure, different workflow.
- No token/secret/permissions changes needed.