### PR TITLE
[VULN-1563] Bump undici and shell-quote for security fixes

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -11757,9 +11757,9 @@ __metadata:
   linkType: hard
 
 "shell-quote@npm:^1.7.3":
-  version: 1.7.3
-  resolution: "shell-quote@npm:1.7.3"
-  checksum: 10/0ab00c37c84ea3ac13d5f0d45c6850701254fd1d6653d0604a48973ba3911ad0dd9f414672253a01f68fe48bb651a7138317ed4543b75ce4192c1d610e453d4c
+  version: 1.9.0
+  resolution: "shell-quote@npm:1.9.0"
+  checksum: 10/c3bc91e74a469c4f96b6fd13b0c777fff16bcbda202692a4e5402d3d6b78fc6e02fe92fdf8dc0bddf992a9c6758e43207bfc5bdbefbf8a58190b1c885cbcc171
   languageName: node
   linkType: hard
 
@@ -12759,9 +12759,9 @@ __metadata:
   linkType: hard
 
 "undici@npm:^6.25.0":
-  version: 6.25.0
-  resolution: "undici@npm:6.25.0"
-  checksum: 10/a475e45da3e1d1073283bb70531666f09a432eabff2b857bd7063d469a1ee1486192ff61dc0dadbb526673ce1120fee14d66a59b6b17d1e0bd3a4d5f0a52d0a6
+  version: 6.27.0
+  resolution: "undici@npm:6.27.0"
+  checksum: 10/30c18cdb235edf4dd36f8aa3ace1ffaf44060289a7d62ad44c33180d2d74a224015d25574812f62ce9c625b5beb1b0b766495b650fedf356aca11eed7ce2c816
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Bumps `undici` 6.25.0 -> 6.27.0 (transitive, via node-gyp), patching a WebSocket client DoS via fragment count bypass: GHSA-vxpw-j846-p89q / CVE-2026-12151.
- Bumps `shell-quote` 1.7.3 -> 1.9.0 (transitive, via concurrently), patching a newline-escaping vulnerability in `quote()`'s `.op` handling: GHSA-w7jw-789q-3m8p / CVE-2026-9277.
- Both packages were already declared with semver ranges (`^6.25.0` and `^1.7.3` respectively) that permit the patched versions; the lockfile was just stale. Fixed via `yarn up -R undici shell-quote`, a lockfile-only change. No package.json edits, no overrides/resolutions needed.

## Tickets
- https://appfolio.atlassian.net/browse/VULN-1563
- https://appfolio.atlassian.net/browse/VULN-1544

## Test plan
- `yarn install` completed cleanly.
- Confirmed via `yarn why undici` and `yarn why shell-quote` that both now resolve to the patched versions.