### PR TITLE
feat: support dragHandle="inside" on reorderable HasManyFields

### DIFF
--- a/src/components/HasManyFields/HasManyFields.d.ts
+++ b/src/components/HasManyFields/HasManyFields.d.ts
@@ -17,6 +17,7 @@ interface HasManyFieldsPropTypes {
   maximumRows?: number;
   reorderable?: boolean;
   dragHandle?: 'outside' | 'inside';
+  rowClassName?: string;
   value?: HasManyValue[];
   className?: string;
 }

--- a/src/components/HasManyFields/HasManyFields.d.ts
+++ b/src/components/HasManyFields/HasManyFields.d.ts
@@ -16,6 +16,7 @@ interface HasManyFieldsPropTypes {
   minimumRows?: number;
   maximumRows?: number;
   reorderable?: boolean;
+  dragHandle?: 'outside' | 'inside';
   value?: HasManyValue[];
   className?: string;
 }

--- a/src/components/HasManyFields/HasManyFields.js
+++ b/src/components/HasManyFields/HasManyFields.js
@@ -145,7 +145,14 @@ class HasManyFields extends React.Component {
   };
 
   renderHasManyFieldsRow = (key, index, value, dragHandle) => {
-    const { template: Template, disabled, deleteProps, errors, minimumRows } = this.props;
+    const {
+      template: Template,
+      disabled,
+      deleteProps,
+      errors,
+      minimumRows,
+      rowClassName,
+    } = this.props;
     const refProps = this.isStateless(Template) ? {} : { ref: this.setRowReference(index) };
 
     const template = (
@@ -163,6 +170,7 @@ class HasManyFields extends React.Component {
       <HasManyFieldsRow
         onDelete={this.deleteItem(index)}
         key={key}
+        className={rowClassName}
         deletable={this.value.length > minimumRows}
         disabled={disabled}
         deleteProps={deleteProps}

--- a/src/components/HasManyFields/HasManyFields.js
+++ b/src/components/HasManyFields/HasManyFields.js
@@ -9,15 +9,22 @@ import HasManyFieldsRow from './HasManyFieldsRow';
 
 const DragHandler = withDragHandler();
 
-const SortableItem = ReorderableElement(({ key, sortIndex, value, renderHasManyFieldsRow }) => (
-  <div className="d-flex js-reorderable-item" key={key}>
-    <DragHandler />
-    <div className="w-100">{renderHasManyFieldsRow(null, sortIndex, value)}</div>
-  </div>
-));
+const SortableItem = ReorderableElement(
+  ({ key, sortIndex, value, renderHasManyFieldsRow, dragHandleInside }) =>
+    dragHandleInside ? (
+      <div className="js-reorderable-item" key={key}>
+        {renderHasManyFieldsRow(null, sortIndex, value, <DragHandler />)}
+      </div>
+    ) : (
+      <div className="d-flex js-reorderable-item" key={key}>
+        <DragHandler />
+        <div className="w-100">{renderHasManyFieldsRow(null, sortIndex, value)}</div>
+      </div>
+    )
+);
 
 const SortableContainer = ReorderableContainer(
-  ({ value, renderAddRow, renderHasManyFieldsRow }) => (
+  ({ value, renderAddRow, renderHasManyFieldsRow, dragHandleInside }) => (
     <div>
       {value.map((item, index) => (
         <SortableItem
@@ -25,6 +32,7 @@ const SortableContainer = ReorderableContainer(
           index={index}
           sortIndex={index}
           value={item}
+          dragHandleInside={dragHandleInside}
           renderHasManyFieldsRow={renderHasManyFieldsRow}
         />
       ))}
@@ -44,6 +52,7 @@ class HasManyFields extends React.Component {
     minimumRows: 1,
     maximumRows: Infinity,
     reorderable: false,
+    dragHandle: 'outside',
   };
 
   constructor(props) {
@@ -135,9 +144,20 @@ class HasManyFields extends React.Component {
     return isFunction && !(Template.prototype && Template.prototype.render);
   };
 
-  renderHasManyFieldsRow = (key, index, value) => {
+  renderHasManyFieldsRow = (key, index, value, dragHandle) => {
     const { template: Template, disabled, deleteProps, errors, minimumRows } = this.props;
     const refProps = this.isStateless(Template) ? {} : { ref: this.setRowReference(index) };
+
+    const template = (
+      <Template
+        value={value}
+        errors={errors[index]}
+        onChange={this.updateItem(index)}
+        disabled={disabled}
+        index={index}
+        {...refProps}
+      />
+    );
 
     return (
       <HasManyFieldsRow
@@ -147,20 +167,22 @@ class HasManyFields extends React.Component {
         disabled={disabled}
         deleteProps={deleteProps}
       >
-        <Template
-          value={value}
-          errors={errors[index]}
-          onChange={this.updateItem(index)}
-          disabled={disabled}
-          index={index}
-          {...refProps}
-        />
+        {dragHandle ? (
+          <div className="d-flex">
+            {dragHandle}
+            <div className="w-100" style={{ minWidth: 0 }}>
+              {template}
+            </div>
+          </div>
+        ) : (
+          template
+        )}
       </HasManyFieldsRow>
     );
   };
 
   render() {
-    const { className, disabled, reorderable } = this.props;
+    const { className, disabled, reorderable, dragHandle } = this.props;
 
     if (!disabled && reorderable) {
       return (
@@ -172,6 +194,7 @@ class HasManyFields extends React.Component {
             useDragHandle
             lockAxis="y"
             value={this.value}
+            dragHandleInside={dragHandle === 'inside'}
             renderHasManyFieldsRow={this.renderHasManyFieldsRow}
             renderAddRow={this.renderAddRow}
           />

--- a/src/components/HasManyFields/HasManyFields.spec.js
+++ b/src/components/HasManyFields/HasManyFields.spec.js
@@ -310,4 +310,14 @@ describe('<HasManyFields />', () => {
       });
     });
   });
+
+  it('passes rowClassName through to each row', () => {
+    const component = mount(
+      <HasManyFields value={items} template={Input} label="Add an Animal" rowClassName="border rounded p-3" />
+    );
+
+    component.find(HasManyFieldsRow).forEach((row) => {
+      assert.equal('border rounded p-3', row.prop('className'));
+    });
+  });
 });

--- a/src/components/HasManyFields/HasManyFields.spec.js
+++ b/src/components/HasManyFields/HasManyFields.spec.js
@@ -274,6 +274,40 @@ describe('<HasManyFields />', () => {
         assert.equal(items.length, component.find('.js-reorderable-item').length);
         assert.equal(items.length, component.find(HasManyFieldsRow).length);
       });
+
+      it('renders drag handles outside the rows by default', () => {
+        assert.equal(items.length, component.find('div.rg-DragHandler').length);
+        assert.equal(0, component.find(HasManyFieldsRow).at(0).find('div.rg-DragHandler').length);
+      });
+    });
+  });
+
+  describe('reorderable with dragHandle="inside"', () => {
+    let component;
+
+    beforeEach(() => {
+      component = mount(
+        <HasManyFields
+          value={items}
+          errors={errors}
+          template={Input}
+          blank="foo"
+          label="Add an Animal"
+          reorderable
+          dragHandle="inside"
+        />
+      );
+    });
+
+    it('has correct number of reorderable items', () => {
+      assert.equal(items.length, component.find('.js-reorderable-item').length);
+      assert.equal(items.length, component.find(HasManyFieldsRow).length);
+    });
+
+    it('renders each drag handle inside its row', () => {
+      component.find(HasManyFieldsRow).forEach((row) => {
+        assert.equal(1, row.find('div.rg-DragHandler').length);
+      });
     });
   });
 });

--- a/src/components/HasManyFields/HasManyFields.stories.js
+++ b/src/components/HasManyFields/HasManyFields.stories.js
@@ -67,6 +67,7 @@ LiveExample.args = {
   maximumRows: 5,
   reorderable: false,
   dragHandle: 'outside',
+  rowClassName: '',
 };
 LiveExample.argTypes = {
   dragHandle: {

--- a/src/components/HasManyFields/HasManyFields.stories.js
+++ b/src/components/HasManyFields/HasManyFields.stories.js
@@ -66,6 +66,13 @@ LiveExample.args = {
   minimumRows: 1,
   maximumRows: 5,
   reorderable: false,
+  dragHandle: 'outside',
+};
+LiveExample.argTypes = {
+  dragHandle: {
+    control: 'radio',
+    options: ['outside', 'inside'],
+  },
 };
 
 export const RowWrapper = (args) => (


### PR DESCRIPTION
## What

Two additive props on `HasManyFields`:
- `dragHandle="inside"` — renders the reorderable drag handle inside each `HasManyFieldsRow` (before the row content) instead of prepending it outside the row.
- `rowClassName` — passed through as `className` to each `HasManyFieldsRow` (which already accepts it), e.g. `"border rounded p-3"` for a card-style row.

Together they enable card-style reorderable rows: border wrapping handle + content + delete button.

## Why

With the current layout, the handle sits to the left of the row inside the same column as the row content, indenting every reorderable row by ~2rem. In forms where reorderable rows sit alongside regular inputs (e.g. Property's owner packet settings and owner packet send flow), the rows no longer align with the other fields. Current UX designs place the handle inside a bordered row card spanning the full column.

## Risk

Low — defaults (`dragHandle="outside"`, no `rowClassName`) preserve the existing markup; the new layout only applies to consumers that opt in. Covered by new jest cases for both handle placements and the row class pass-through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)